### PR TITLE
Create BMI metadata directory

### DIFF
--- a/.bmi.yaml
+++ b/.bmi.yaml
@@ -1,0 +1,6 @@
+bmi_paths:
+  - .bmi/frost_number
+  - .bmi/ku
+
+build:
+  - python setup.py develop

--- a/.bmi/frost_number/info.yaml
+++ b/.bmi/frost_number/info.yaml
@@ -1,0 +1,7 @@
+author: J. Scott Stewart
+doi:
+email:
+license:
+summary:
+url:
+version:

--- a/.bmi/ku/info.yaml
+++ b/.bmi/ku/info.yaml
@@ -1,0 +1,7 @@
+author: Kang Wang
+doi:
+email:
+license:
+summary:
+url:
+version:

--- a/.gitignore
+++ b/.gitignore
@@ -64,8 +64,9 @@ target/
 #Ipython Notebook
 .ipynb_checkpoints
 
+# NetCDF data files
 *.nc
 
-*.nc
+# Emacs backups
+*~
 
-*.nc


### PR DESCRIPTION
I've created the BMI metadata directory, **.bmi**, and included subdirectories for the Ku and FrostNumber components. In each component directory, I stubbed out the **info.yaml** file. I also added the top-level **.bmi.yaml** file with paths to the component directories.

**Todo:**
- Complete **info.yaml** file
- Add **api.yaml**, **parameters.yaml**, and **.tmpl** version of each component's input file

For examples of how to construct these files, look at the components in the **.bmi** directory of https://github.com/mdpiper/topoflow.
