### PR TITLE
Correct use of bmi-tester and remove dependence on tf_utils

### DIFF
--- a/permamodel/examples/install_pm.sh
+++ b/permamodel/examples/install_pm.sh
@@ -106,7 +106,7 @@ echo "  cd $dirname"
 echo "  . ./use_this_env"
 echo "  cd permamodel"
 echo "    nosetests -x"
-echo "    bmi-tester permamodel.components.frost_number.FrostnumberMethod"
+echo "    bmi-tester permamodel.components.bmi_frost_number.BmiFrostnumberMethod"
 exit
 
 # Other things to add?

--- a/permamodel/utils/pixels.py
+++ b/permamodel/utils/pixels.py
@@ -26,8 +26,6 @@
 from numpy import *
 import numpy
 
-from tf_utils import TF_Print
-
 #-------------------------------------------------------------------
 def unit_test():
 
@@ -187,15 +185,15 @@ def get_da(rti, METERS=False, REPORT=False, VERBOSE=False):
         da = (dx[0] * dy[0])
 
         if (VERBOSE):
-            TF_Print('dx = ' + str(dx[0]) + '  [m]')
-            TF_Print('dy = ' + str(dy[0]) + '  [m]')
-            TF_Print('da = ' + str(da) + '  [m^2]')
+            print('dx = ' + str(dx[0]) + '  [m]')
+            print('dy = ' + str(dy[0]) + '  [m]')
+            print('da = ' + str(da) + '  [m^2]')
     else:
         #---------------------------------
         # Convert da from 1D to 2D array
         # Then subscript with the wk's.
         #---------------------------------
-        TF_Print('Computing pixel area grid...')
+        print('Computing pixel area grid...')
         nx = rti.ncols
         ny = rti.nrows
 
@@ -216,17 +214,17 @@ def get_da(rti, METERS=False, REPORT=False, VERBOSE=False):
         if (VERBOSE):
             da_min = da.min()
             da_max = da.max()
-            TF_Print('    min(da) = ' + str(da_min) + '  [m^2]')
-            TF_Print('    max(da) = ' + str(da_max) + '  [m^2]')
+            print('    min(da) = ' + str(da_min) + '  [m^2]')
+            print('    max(da) = ' + str(da_max) + '  [m^2]')
             dx_min = dx.min()
             dx_max = dx.max()
-            TF_Print('    min(dx) = ' + str(dx_min) + '  [m]')
-            TF_Print('    max(dx) = ' + str(dx_max) + '  [m]')
+            print('    min(dx) = ' + str(dx_min) + '  [m]')
+            print('    max(dx) = ' + str(dx_max) + '  [m]')
             dy_min = dy.min()
             dy_max = dy.max()
-            TF_Print('    min(dy) = ' + str(dy_min) + '  [m]')
-            TF_Print('    max(dy) = ' + str(dy_max) + '  [m]')
-            TF_Print(' ')
+            print('    min(dy) = ' + str(dy_min) + '  [m]')
+            print('    max(dy) = ' + str(dy_max) + '  [m]')
+            print(' ')
 
     return da
 


### PR DESCRIPTION
With the move of all BMI routines into its own source code file, the command to use bmi-tester changed.  This change is now corrected in the install_pm.sh script.

Also, Eric found an unnecessary dependence on tf_utils with TF_Print in utils/pixels.py.  These commands have been replaced by simple print statements.  Note: there is likely a lot of code cleanup to be done here; I don't think I'm aware of any current dependence of the code on pixels.py.
