### PR TITLE
Use zero-based time in model

### DIFF
--- a/permamodel/components/bmi_frost_number.py
+++ b/permamodel/components/bmi_frost_number.py
@@ -211,9 +211,6 @@ class BmiFrostnumberMethod( perma_base.PermafrostComponent ):
 
     #   get_var_units()
     #-------------------------------------------------------------------
-    def get_current_time(self):
-        # For the frostnumber component, the time is simply the year
-        return self._model.year
 
     def update(self):
         # Ensure that we've already initialized the run
@@ -268,8 +265,14 @@ class BmiFrostnumberMethod( perma_base.PermafrostComponent ):
             self._model.print_final_report(\
                     comp_name='Permamodel FrostNumber component')
 
+    def get_start_time(self):
+        return 0.0
+
+    def get_current_time(self):
+        return self._model.year - self._model.start_year
+
     def get_end_time(self):
-        return self._model.end_year
+        return self._model.end_year - self._model.start_year + 1.0
 
     # ----------------------------------
     # Functions added to pass bmi-tester

--- a/permamodel/components/bmi_frost_number.py
+++ b/permamodel/components/bmi_frost_number.py
@@ -216,15 +216,15 @@ class BmiFrostnumberMethod( perma_base.PermafrostComponent ):
         # Ensure that we've already initialized the run
         assert(self._model.status == 'initialized')
 
+        # Calculate the new frost number values
+        self._model.calculate_frost_numbers()
+        self._values['frostnumber__air'] = self._model.air_frost_number
+
         # Update the time
         self._model.year += self._model.dt
 
         # Get new input values
         self._model.read_input_files()
-
-        # Calculate the new frost number values
-        self._model.calculate_frost_numbers()
-        self._values['frostnumber__air'] = self._model.air_frost_number
 
     def update_until(self, stop_year):
         # Ensure that stop_year is at least the current year

--- a/permamodel/tests/test_frost_number_bmi.py
+++ b/permamodel/tests/test_frost_number_bmi.py
@@ -58,6 +58,7 @@ def test_frost_number_update_changes_air_frost_number():
     fn = bmi_frost_number.BmiFrostnumberMethod()
     fn.initialize(cfg_file=onesite_multiyear_filename)
 
+    fn.update()
     afn0 = fn._model.air_frost_number
     fn.update()
     afn1 = fn._model.air_frost_number


### PR DESCRIPTION
In WMT, model time is assumed to start at zero. (It's planned to eventually change this.) Permamodel, however, starts at `start_year`. I updated the BMI methods `get_start_time`, `get_current_time`, and `get_end_time` to offset from `start_year` back to zero.

Also, following the pattern in [bmi_heat.py](https://github.com/csdms/bmi-live/blob/master/heat_solver/bmi_heat.py), I calculated the new model state before advancing the model time.

I think @sc0tts and I should discuss these changes before they're merged. I'm pretty sure (but not entirely confident) that I've done the right thing for both permamodel and WMT. 
