### PR TITLE
Minor updates to Frostnumber and install script

### DIFF
--- a/permamodel/__init__.py
+++ b/permamodel/__init__.py
@@ -1,5 +1,5 @@
 
-SILENT = False
+SILENT = True
 
 #if not(SILENT):
 #    print 'Importing PermaModel packages:'

--- a/permamodel/components/bmi_frost_number.py
+++ b/permamodel/components/bmi_frost_number.py
@@ -274,7 +274,9 @@ class BmiFrostnumberMethod( perma_base.PermafrostComponent ):
             self.update()
             year = self._model.year
 
-    def finalize(self, SILENT=True):
+    def finalize(self):
+        SILENT = True
+
         # Finish with the run
         self._model.status = 'finalizing'  # (OpenMI)
 

--- a/permamodel/components/frost_number.py
+++ b/permamodel/components/frost_number.py
@@ -43,8 +43,12 @@ class FrostnumberMethod( perma_base.PermafrostComponent ):
             self.T_air_max = T_air_max
 
     def initialize_frostnumber_component(self):
+        SILENT = True
+
         # Note: Initialized from initialize() in perma_base.py
-        print("Initializing for FrostnumberMethod")
+        if not SILENT:
+            print("Initializing for FrostnumberMethod")
+
         self._model = 'FrostNumber'
 
         # Here, initialize the variables which are unique to the

--- a/permamodel/components/perma_base.py
+++ b/permamodel/components/perma_base.py
@@ -176,16 +176,17 @@ class PermafrostComponent( BMI_base.BMI_component ):
         # SILENT and mode were original optional arguments
         #   they should be removed, but are simply defined here for brevity
 
-        SILENT = False
+        SILENT = True
 
-        if not(SILENT):
+        if not SILENT:
             print 'Permafrost component: Initializing...'
 
         self.status     = 'initializing'  # (OpenMI 2.0 convention)
 
         # Set the cfg file if it exists, otherwise, a default
         if os.path.isfile(cfg_file):
-            print("passed cfg_file: %s" % cfg_file)
+            if not SILENT:
+                print("passed cfg_file: %s" % cfg_file)
             self.cfg_file = cfg_file
         else:
             cfg_file = \

--- a/permamodel/examples/install_pm.sh
+++ b/permamodel/examples/install_pm.sh
@@ -107,6 +107,10 @@ echo "  . ./use_this_env"
 echo "  cd permamodel"
 echo "    nosetests -x"
 echo "    bmi-tester permamodel.components.bmi_frost_number.BmiFrostnumberMethod"
+echo "If you want to add a non-standard conda package--e.g. rednose for nosetests:"
+echo "  conda install -y anaconda-client"
+echo "  conda install -y --channel https://conda.anaconda.org/blaze rednose"
+
 exit
 
 # Other things to add?

--- a/permamodel/examples/install_pm.sh
+++ b/permamodel/examples/install_pm.sh
@@ -32,9 +32,9 @@ echo "Downloading latest miniconda repository..."
 this_os=`uname`
 echo "this_os: ...$this_os..."
 if [ $this_os = 'Linux' ]; then
-  curl http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -o miniconda.sh
+  curl https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -o miniconda.sh
 elif [ $this_os = 'Darwin' ]; then
-  curl http://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -o miniconda.sh
+  curl https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -o miniconda.sh
 else
 	echo "Operating system not recognized as mac or linux: $this_os"
 	exit

--- a/run_bmi-tester_frostnumber
+++ b/run_bmi-tester_frostnumber
@@ -1,0 +1,1 @@
+bmi-tester permamodel.components.bmi_frost_number.BmiFrostnumberMethod 


### PR DESCRIPTION
A few minor updates to the Frostnumber component of Permamodel, a testing script, and the install script.

1) BMI functions cannot have optional arguments, but we had "SILENT=False" on some of the functions, such as finalize.  These have been removed and the default has been set--in the modules themselves--to "True"

2) The script 'install_pm.sh' lets you install everything into a directory--including all the Permamodel code and its own version of Python.  Recently, Continuum Analytics--the people who put out the version of Python that we download with this--changed the way their repository needed to be accessed.  These changes are incorporated into the 'install_pm.sh' script now.

3) Eric's "bmi-tester" routine is included in what is downloaded with the install script.  It's a rather long command to type, I put the call to bmi-tester in a file named 'run_bmi-tester_frostnumber' so that you just have to run that file instead of typing:
   bmi-tester permamodel.components.bmi_frost_number.BmiFrostnumberMethod 
