### PR TITLE
Update Travis CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: python
 python:
-  - "2.7"
-sudo: false
+  - "2.7_with_system_site_packages"
 before_install:
+  - sudo apt-get install -qq python-numpy python-scipy
   - pip install nose
-  - pip install numpy
-  - pip install scipy
   - pip install netCDF4
   - pip install affine
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.7"
 before_install:
+  - pip install --upgrade pip setuptools wheel
   - pip install nose
   - pip install --only-binary=numpy numpy
   - pip install --only-binary=scipy scipy

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ sudo: false
 before_install:
   - pip install nose
   - pip install numpy
-  - pip install hdf5
-  - pip install netCDF4
   - pip install scipy
+  - pip install netCDF4
   - pip install affine
 install:
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: python
 python:
   - "2.7"
 sudo: false
+before_install:
+  - pip install nose
+  - pip install numpy
+  - pip install netCDF4
+  - pip install scipy
+  - pip install affine
 install:
   - python setup.py install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 before_install:
   - pip install nose
   - pip install numpy
+  - pip install hdf5
   - pip install netCDF4
   - pip install scipy
   - pip install affine

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
 python:
-  - "2.7_with_system_site_packages"
+  - "2.7"
 before_install:
-  - sudo apt-get install -qq python-numpy python-scipy
   - pip install nose
-  - pip install netCDF4
+  - pip install --only-binary=numpy numpy
+  - pip install --only-binary=scipy scipy
+  - pip install --only-binary=netcdf4 netcdf4
   - pip install affine
 install:
   - python setup.py install


### PR DESCRIPTION
Permamodel requires additional packages, such as numpy and scipy. Although these packages are listed in **setup.py**, it's not a good idea to let setuptools install them, since it tries to build them from source, which is time-consuming and fraught with error. I thought it would be easy to install them with `pip`. It wasn't. I had to update `pip` on Travis, then install binary-only packages for numpy, scipy, and netcdf4; otherwise, they failed. Note that I stubbornly stuck with the default Python on Travis, and intentionally didn't use miniconda. That was, in hindsight, a mistake.