### PR TITLE
Add data files for KuModel to package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,7 @@ setup(name='permamodel',
       packages=find_packages(),
       #install_requires=('numpy', 'nose', 'gdal', 'pyproj'),
       install_requires=('affine', 'netCDF4', 'scipy', 'numpy', 'nose',),
-      package_data={'': ['examples/*.cfg', 'examples/*.dat']}
+      package_data={'': ['examples/*.cfg',
+                         'examples/*.dat',
+                         'components/Parameters/*']}
 )


### PR DESCRIPTION
This was easier than I thought it would be because @sc0tts has already added package data for FrostNumberModel. However, KuModel can't find the package data when instantiated from a directory outside of the repository. I'll open a separate issue for this.