### PR TITLE
cleaner test results

### DIFF
--- a/permamodel/__init__.py
+++ b/permamodel/__init__.py
@@ -16,10 +16,10 @@ tests_directory = os.path.join(permamodel_directory, 'tests')
 
 SILENT = True
 
-if not(SILENT):
-    print("Importing permamodel.utils...")
-import permamodel.utils
-
-if not(SILENT):
-    print("Importing permamodel.components...")
-import permamodel.components
+#if not(SILENT):
+#    print("Importing permamodel.utils...")
+#import permamodel.utils
+#
+#if not(SILENT):
+#    print("Importing permamodel.components...")
+#import permamodel.components

--- a/permamodel/__init__.py
+++ b/permamodel/__init__.py
@@ -13,13 +13,3 @@ permamodel_directory = os.path.dirname(__file__)
 data_directory = os.path.join(permamodel_directory, 'data')
 examples_directory = os.path.join(permamodel_directory, 'examples')
 tests_directory = os.path.join(permamodel_directory, 'tests')
-
-SILENT = True
-
-#if not(SILENT):
-#    print("Importing permamodel.utils...")
-#import permamodel.utils
-#
-#if not(SILENT):
-#    print("Importing permamodel.components...")
-#import permamodel.components

--- a/permamodel/components/bmi_frost_number.py
+++ b/permamodel/components/bmi_frost_number.py
@@ -174,6 +174,7 @@ class BmiFrostnumberMethod( perma_base.PermafrostComponent ):
 
         # initialize() tasks complete.  Update status.
         self.status = 'initialized'
+        #print(self._model)
 
     def get_attribute(self, att_name):
 

--- a/permamodel/examples/run_bmi-tester_frostnumber
+++ b/permamodel/examples/run_bmi-tester_frostnumber
@@ -1,0 +1,6 @@
+# Run this from the root "permamodel" directory
+#  e.g., the one that contains the ez_setup.py and README.md files
+#
+#  . ./permamodel/examples/run_bmi-tester_frostnumber
+
+bmi-tester permamodel.components.bmi_frost_number.BmiFrostnumberMethod 

--- a/permamodel/examples/run_test_BMI_frost_number.py
+++ b/permamodel/examples/run_test_BMI_frost_number.py
@@ -10,9 +10,7 @@ Created on Tue Jan 10 10:56:16 2017
 """
 
 import os
-import sys
 from permamodel.components import bmi_frost_number
-#from .. import examples_directory
 from permamodel import examples_directory
 
 

--- a/permamodel/examples/run_test_BMI_frost_number.py
+++ b/permamodel/examples/run_test_BMI_frost_number.py
@@ -12,7 +12,8 @@ Created on Tue Jan 10 10:56:16 2017
 import os
 import sys
 from permamodel.components import bmi_frost_number
-from .. import examples_directory
+#from .. import examples_directory
+from permamodel import examples_directory
 
 
 cfg_file = os.path.join(examples_directory,

--- a/permamodel/examples/run_test_BMI_ku_model.py
+++ b/permamodel/examples/run_test_BMI_ku_model.py
@@ -10,9 +10,7 @@ Created on Tue Jan 10 10:56:16 2017
 """
 
 import os
-import sys
 from permamodel.components import bmi_Ku_component
-#from .. import examples_directory
 from permamodel import examples_directory
 
 

--- a/permamodel/examples/run_test_BMI_ku_model.py
+++ b/permamodel/examples/run_test_BMI_ku_model.py
@@ -12,7 +12,8 @@ Created on Tue Jan 10 10:56:16 2017
 import os
 import sys
 from permamodel.components import bmi_Ku_component
-from .. import examples_directory
+#from .. import examples_directory
+from permamodel import examples_directory
 
 
 cfg_file = os.path.join(examples_directory, 'Ku_method.cfg')

--- a/permamodel/tests/run_bmi-tester_frostnumber
+++ b/permamodel/tests/run_bmi-tester_frostnumber
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-bmi-tester permamodel.components.bmi_frost_number.BmiFrostnumberMethod 


### PR DESCRIPTION
I had originally opened this branch to track down a few remaining issues with leftover files from nosetests.  In the process, I learned a few things about how nosetests chooses the files that it runs when automatically collecting all the tests to run.

One of the benefits of the changes in this pull request is that an extraneous files that are created when running the standalone BMI routines for Ku model and Frost number are no longer generated when running nosetests.

Here are the changes:

1) In __init__.py, there was some old code about importing permamodel.utils and permamodel.components.  I think these are holdovers from Topoflow and are not needed.  I'm not completely sure, however.  So I left the code here but commented it out.  All tests still pass.

2) bmi_frost_number.py was unnecessarily printing its own memory handle.

3) added some info at the beginning of "run_bmi-tester_frostnumber" about how to invoke it.  Also moved this code from /tests subdirectory to /examples.

4) Moved the standalone run_test_BMI_... for frost_number and Ku models from the /tests to the /examples directories.  I think this is the more natural place for these example files to be located.