### PR TITLE
Set cfg_directory based on os.path.realpath

### DIFF
--- a/permamodel/utils/BMI_base.py
+++ b/permamodel/utils/BMI_base.py
@@ -1767,7 +1767,7 @@ class BMI_component:
         # the "." to the full CFG_file directory. (9/21/14)
         #------------------------------------------------------------
         if (self.cfg_file != None):
-            cfg_directory = os.path.dirname(self.cfg_file) + os.sep
+            cfg_directory = os.path.dirname(os.path.realpath(self.cfg_file))
             ## print 'cfg_directory =', cfg_directory
             self.cfg_directory = cfg_directory
             if (self.in_directory[0] == '.'):


### PR DESCRIPTION
This lets the .cfg file be passed to `initialize` with an absolute or a relative path.

This is an issue that was fixed in Topoflow, but not ported over to permamodel. See https://github.com/mdpiper/topoflow/commit/5e7bd4617bf798f6b3e3c8bf13f442751b25898f#diff-a09672c89160a4b2d9944ee116f67bc7.