### PR TITLE
changed argument to update_until() to be timestep rather than year

### DIFF
--- a/permamodel/components/frost_number.py
+++ b/permamodel/components/frost_number.py
@@ -333,7 +333,8 @@ class FrostnumberMethod(perma_base.PermafrostComponent):
     def update(self, frac=None):
         """ Move to the next timestep and update calculations """
         if frac is not None:
-            print("Fractional times not yet permitted, rounding to nearest int")
+            # print(
+            #     "Fractional times not yet permitted, rounding to nearest int")
             time_change = self.dt * int(frac + 0.5)
         else:
             time_change = self.dt

--- a/permamodel/examples/Frostnumber_example_singlesite_multiyear.cfg
+++ b/permamodel/examples/Frostnumber_example_singlesite_multiyear.cfg
@@ -11,7 +11,7 @@ case_prefix     | case_test                 | string   | file prefix for the mod
 T_air_min_type  | Time_Series               | string   | allowed input types {Scalar; Time_Series}
 T_air_min       | fn_t_air_min.dat          | string   | Mean annual air temperature [C]
 T_air_max_type  | Time_Series               | string   | allowed input types {Scalar; Time_Series}
-T_air_max       | fn_t_air_min.dat          | string   | Mean annual air temperature [C]
+T_air_max       | fn_t_air_max.dat          | string   | Mean annual air temperature [C]
 start_year      | 2000                      | float    | begining of the simulation time [year]
 end_year        | 2003                      | float    | begining of the simulation time [year]
 dt              | 1.0                       | float    | timestep for permafrost process [year]

--- a/permamodel/examples/try_fn.py
+++ b/permamodel/examples/try_fn.py
@@ -11,10 +11,10 @@ Usage:
 import os
 from permamodel.components import frost_number
 from permamodel.components import bmi_frost_number
-from permamodel.tests import examples_directory
+from permamodel import examples_directory
 
 # Set the file names for the example cfg files
-onesite_oneyear_filename = \
+onesite_singleyear_filename = \
         os.path.join(examples_directory,
                      'Frostnumber_example_singlesite_singleyear.cfg')
 onesite_multiyear_filename = \
@@ -22,10 +22,14 @@ onesite_multiyear_filename = \
                      'Frostnumber_example_singlesite_multiyear.cfg')
 
 
-#fn = frost_number.frostnumber_method()
+fn = bmi_frost_number.BmiFrostnumberMethod()
+fn.initialize(cfg_file=onesite_singleyear_filename)
+fn.update_until(fn.get_end_time())
+fn.finalize()
+print('Successfully finished running singleyear FrostNumber component')
+
 fn = bmi_frost_number.BmiFrostnumberMethod()
 fn.initialize(cfg_file=onesite_multiyear_filename)
 fn.update_until(fn.get_end_time())
 fn.finalize()
-
-print('Successfully finished running the Permamodel FrostNumber component!')
+print('Successfully finished running multiyear FrostNumber component')


### PR DESCRIPTION
There were a few issues here:

1) end_time was giving too high a value, as if the timestep numbering started at 1 instead of at 0.  This caused loops that used end_time to never end

2) the BMI update_until() function was using years rather than timesteps as the units of its argument.  That is...not ideal, so here it is changed to timesteps.

3) The 'try_fn.py' example code was used here to test the code and needed to be updated to work with the current code.  There was also a typo in an example config file that caused both min and max temp files to be the same.