### PR TITLE
Ground surface FN

### DIFF
--- a/permamodel/components/bmi_frost_number.py
+++ b/permamodel/components/bmi_frost_number.py
@@ -58,21 +58,27 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
 
         self._input_var_names = (
             'atmosphere_bottom_air__temperature',
+            'snowpack__depth',
+            'snowpack__density',
             )
 
         self._output_var_names = (
             'frostnumber__air',            # Air Frost number
             'frostnumber__surface',        # Surface Frost number
-            'frostnumber__stefan')        # Stefan Frost number
+            'frostnumber__stefan')         # Stefan Frost number
 
         self._var_name_map = {
             'atmosphere_bottom_air__temperature':  'T_air_min',
+            'snowpack__depth':                     'h_snow',
+            'snowpack__density':                   'rho_snow',
             'frostnumber__air':                    'air_frost_number',
             'frostnumber__surface':                'surface_frost_number',
             'frostnumber__stefan':                 'stefan_frost_number'}
 
         self._var_units_map = {
             'atmosphere_bottom_air__temperature':   'deg_C',
+            'snowpack__depth':                      'm',
+            'snowpack__density':                    'kg m-3',
             'frostnumber__air':                     '1',
             'frostnumber__surface':                 '1',
             'frostnumber__stefan':                  '1'}
@@ -114,6 +120,8 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
             # These are the links to the model's variables and
             # should be consistent with _var_name_map
             'atmosphere_bottom_air__temperature':    self._model.T_air,
+            'snowpack__depth':                       self._model.h_snow,
+            'snowpack__density':                     self._model.rho_snow,  
             'frostnumber__air':         self._model.air_frost_number,
             'frostnumber__surface':     self._model.surface_frost_number,
             'frostnumber__stefan':      self._model.stefan_frost_number}

--- a/permamodel/components/frost_number.py
+++ b/permamodel/components/frost_number.py
@@ -264,6 +264,7 @@ class FrostnumberMethod(perma_base.PermafrostComponent):
         assert_greater_equal(T_hot, T_cold)
         T_avg = (T_hot + T_cold) / 2.0
         T_winter = -99.
+        Beta     = -99.
 
         # Note that these conditions should cover T_hot == T_cold
         if T_hot <= 0:

--- a/permamodel/components/frost_number.py
+++ b/permamodel/components/frost_number.py
@@ -53,7 +53,7 @@ class FrostnumberMethod(perma_base.PermafrostComponent):
         self.ddt = []
         self.ddf = []
         self.h_snow = -99.0
-        self.c_snow = -99.0
+        self.Csn    = -99.0
         self.Fplus = -99.0
         self.Twplus = -99.0
         self.Zfplus = -99.0
@@ -69,12 +69,15 @@ class FrostnumberMethod(perma_base.PermafrostComponent):
         self.A_air = -1.0
         self.lat = -999
         self.lon = -999
-        self.rho_snow = 0.0
+        self.rho_snow = -99.0
         self.vwc_H2O = 0.0
         self.Hvgf = 0.0
         self.Hvgt = 0.0
         self.Dvf = 0.0
         self.Dvt = 0.0
+        
+        self.surface_frost_number_on = False
+        self.sec_per_year            = 365.0*24.0*3600.
 
     def dummy_file(self, instring=""):
         """ dummy file class, so can declare empty variable in __init__()
@@ -116,9 +119,13 @@ class FrostnumberMethod(perma_base.PermafrostComponent):
         self.fn_out_filename = self._configuration['fn_out_filename']
         
         # Snow cover:
-        self.h_snow   = self._configuration['h_snow']
-        self.rho_snow = self._configuration['rho_snow']
-        
+        try:
+            self.h_snow   = self._configuration['h_snow']
+            self.rho_snow = self._configuration['rho_snow']
+        except:
+            self.h_snow    = -99
+            self.rho_snow  = -99
+            
         # These don't need to be used after this routine
         T_air_min_type = self._configuration['T_air_min_type']
         T_air_max_type = self._configuration['T_air_max_type']
@@ -146,6 +153,10 @@ class FrostnumberMethod(perma_base.PermafrostComponent):
             assert_true(os.path.isfile(fname))
             Tvalues = np.loadtxt(fname, skiprows=0, unpack=False)
             self.T_air_max = np.array(Tvalues, dtype=np.float32)
+            
+        if ((self.h_snow > 0) & (self.rho_snow > 0)):
+            self.surface_frost_number_on = True
+
 
     def initialize_frostnumber_component(self):
         """ Set the starting values for the frostnumber component """
@@ -178,6 +189,28 @@ class FrostnumberMethod(perma_base.PermafrostComponent):
         self.output[self.year] = ("%5.3f" % self.air_frost_number,
                                   "%5.3f" % self.surface_frost_number,
                                   "%5.3f" % self.stefan_frost_number)
+        
+    def estimate_snow_damping(self):
+
+        #--------------------------------------------------
+        
+        rho_sn=self.rho_snow
+
+        self.Ksn = rho_sn**3 * 2.2E-9 + rho_sn * 4.2E-4 + 2.1E-2; # Unit: (W m-1 C-1)
+
+        self.Csn = 2115 + 7.79 * self.T_winter;
+        
+        self.alpha_sn = self.Ksn / (self.Csn * rho_sn)
+        
+        self.Z_sn_star = np.sqrt(self.alpha_sn * self.sec_per_year/np.pi ) 
+        
+        self.A_plus = self.T_amplitude * np.exp(-1.*self.h_snow / self.Z_sn_star)
+        
+        self.T_winter_plus = self.T_average - self.A_plus *  \
+                             np.sin(self.Beta) / (np.pi - self.Beta)
+        
+        self.ddf_plus = -self.T_winter_plus * self.L_winter
+        
 
     def print_frost_numbers(self, year=-1):
         """ Print output to screen """
@@ -200,7 +233,13 @@ class FrostnumberMethod(perma_base.PermafrostComponent):
     def calculate_surface_frost_number(self):
         """ Dummy value for surface frost number """
         # For now, a dummy value
+        
         self.surface_frost_number = np.float32(-1.0)
+        
+        if (self.surface_frost_number_on == True):
+            self.estimate_snow_damping()
+            self.surface_frost_number = np.sqrt(self.ddf_plus) /\
+                          (np.sqrt(self.ddf_plus) + np.sqrt(self.ddt))
 
     def calculate_stefan_frost_number(self):
         """ Dummy value for Stefan frost number """
@@ -254,10 +293,16 @@ class FrostnumberMethod(perma_base.PermafrostComponent):
             L_winter = 365.0 - L_summer
             ddt = T_summer * L_summer
             ddf = -T_winter * L_winter
+            
         self.T_average = T_average
         self.T_amplitude = T_amplitude
         self.ddt = ddt
         self.ddf = ddf
+        
+        self.T_winter = T_winter
+        self.Beta     = Beta
+        self.L_winter = L_winter
+        
 
     def compute_air_frost_number(self):
         """

--- a/permamodel/components/frost_number.py
+++ b/permamodel/components/frost_number.py
@@ -114,7 +114,11 @@ class FrostnumberMethod(perma_base.PermafrostComponent):
         self.start_year = self._configuration['start_year']
         self.end_year = self._configuration['end_year']
         self.fn_out_filename = self._configuration['fn_out_filename']
-
+        
+        # Snow cover:
+        self.h_snow   = self._configuration['h_snow']
+        self.rho_snow = self._configuration['rho_snow']
+        
         # These don't need to be used after this routine
         T_air_min_type = self._configuration['T_air_min_type']
         T_air_max_type = self._configuration['T_air_max_type']

--- a/permamodel/components/frost_number.py
+++ b/permamodel/components/frost_number.py
@@ -263,6 +263,7 @@ class FrostnumberMethod(perma_base.PermafrostComponent):
 
         assert_greater_equal(T_hot, T_cold)
         T_avg = (T_hot + T_cold) / 2.0
+        T_winter = -99.
 
         # Note that these conditions should cover T_hot == T_cold
         if T_hot <= 0:
@@ -293,6 +294,7 @@ class FrostnumberMethod(perma_base.PermafrostComponent):
             L_winter = 365.0 - L_summer
             ddt = T_summer * L_summer
             ddf = -T_winter * L_winter
+
             
         self.T_average = T_average
         self.T_amplitude = T_amplitude

--- a/permamodel/examples/Frostnumber_example_singlesite_singleyear.cfg
+++ b/permamodel/examples/Frostnumber_example_singlesite_singleyear.cfg
@@ -12,6 +12,10 @@ T_air_min_type  | Scalar                    | string   | allowed input types {Sc
 T_air_min       | -20.0                     | float    | Mean annual air temperature [C]
 T_air_max_type  | Scalar                    | string   | allowed input types {Scalar; Time_Series}
 T_air_max       | 10.0                      | float    | Mean annual air temperature [C]
+h_snow_type     | Scalar                    | string   | allowed input types {Scalar; Grid; Time_Series; Grid_Sequence}
+h_snow          | 0.40                      | float    | depth of snow [m]
+rho_snow_type   | Scalar                    | string   | allowed input types {Scalar; Grid; Time_Series; Grid_Sequence}
+rho_snow        | 240                       | float     | density of snow [kg m-3]
 start_year      | 2000                      | float    | beginning of the simulation time [year]
 end_year        | 2000                      | float    | end of the simulation time [year]
 dt              | 1.0                       | float    | timestep for permafrost process [year]

--- a/permamodel/examples/run_test_BMI_frost_number.py
+++ b/permamodel/examples/run_test_BMI_frost_number.py
@@ -23,3 +23,4 @@ x.update()
 x.finalize()
 
 print x.get_value('frostnumber__air')
+print x.get_value('frostnumber__surface')


### PR DESCRIPTION
added ground surface FN subroutine and BMI.

1) add "estimate_snow_damping" in "frost_number.py" in order to calculate snow effect based on Nelson's method (1997). returns DDF_Plus, i.e., ground surface freezing index.
2) add an option of "surface_frost_number_on", default is False, i.e., ignore ground surface calculation. If both snow depth and snow density are positive. it will be set to "true", the ground surface calculation will be activated.
3) it is tested only for a single site single year.

if there is not any valid input of snow depth or snow density in the configure file, surface frost number will be inactive. 

@sc0tts and @mdpiper, please take some time to review. I will try to migrate it for FN_Geo. Thank you.