### PR TITLE
Fix ku frost_number set values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 before_install:
   - pip install --upgrade pip setuptools wheel
   - pip install coveralls
-  - pip install nose
+  - pip install pytest pytest-cov
   - pip install --only-binary=numpy numpy
   - pip install --only-binary=scipy scipy
   - pip install --only-binary=netcdf4 netcdf4
@@ -14,6 +14,6 @@ before_install:
 install:
   - python setup.py install
 script:
-  - nosetests --with-doctest --with-coverage --cover-package=permamodel
+  - pytest --cov --cov-report=xml:$(pwd)/coverage.xml
 after_success:
   - coveralls --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
 script:
   - pytest --cov --cov-report=xml:$(pwd)/coverage.xml
 after_success:
-  - coveralls --verbose
+  - coveralls

--- a/permamodel/components/Ku_method.py
+++ b/permamodel/components/Ku_method.py
@@ -145,10 +145,12 @@ class Ku_method( perma_base.PermafrostComponent ):
 
         #rti = self.rti # has a problem with loading rti: do not know where its been initialized
 
-        self.thermal_data = np.genfromtxt(self.thermal_parameters_file,
-                                          names = True,
-                                          delimiter=',',
-                                          dtype=None)
+        self.thermal_data = np.genfromtxt(
+            self.thermal_parameters_file,
+            names = True,
+            delimiter=',',
+            # dtype=None,
+        )
 
         #-------------------------------------------------------
         # All grids are assumed to have a data type of Float32.
@@ -573,7 +575,7 @@ class Ku_method( perma_base.PermafrostComponent ):
         n_grid = np.size(self.T_air) 
 
         if n_grid > 1:        
-        
+
             K = self.Kt
             C = self.Ct       
             if np.size(self.Kf)>1:        
@@ -581,14 +583,14 @@ class Ku_method( perma_base.PermafrostComponent ):
             	C[np.where(self.Tps_numerator>0.0)] = self.Cf[np.where(self.Tps_numerator>0.0)]
             
         else:
-            
+
             if self.Tps_numerator<=0.0:
                 K = self.Kt
                 C = self.Ct
             else:
                 K = self.Kf
                 C = self.Cf
-                
+
         Aps = (self.Ags - abs(self.Tps))/np.log((self.Ags+self.L/(2.*C)) / \
                     (abs(self.Tps)+self.L/(2.*C))) - self.L/(2.*C);
 

--- a/permamodel/components/bmi_Ku_component.py
+++ b/permamodel/components/bmi_Ku_component.py
@@ -354,7 +354,8 @@ class BmiKuMethod( perma_base.PermafrostComponent ):
         return self._values[var_name]
 
     def set_value(self, var_name, new_var_values):
-        self._values[var_name] = new_var_values
+        setattr(self._model, self._var_name_map[var_name], new_var_values)
+        # self._values[var_name] = new_var_values
 
     def set_value_at_indices(self, var_name, new_var_values, indices):
         self.get_value_ref(var_name).flat[indices] = new_var_values

--- a/permamodel/components/bmi_Ku_component.py
+++ b/permamodel/components/bmi_Ku_component.py
@@ -433,12 +433,6 @@ class BmiKuMethod( perma_base.PermafrostComponent ):
             if var_name in var_name_list:
                 return grid_id
 
-    def get_grid_shape(self, grid_id):
-        """Number of rows and columns of uniform rectilinear grid."""
-        var_name = self._grids[grid_id]
-        value = np.array(self.get_value_ref(var_name)).shape
-        return value
-
     def get_grid_size(self, grid_id):
         """Size of grid.
 
@@ -453,19 +447,7 @@ class BmiKuMethod( perma_base.PermafrostComponent ):
             Size of grid.
 
         """
-        grid_size = self.get_grid_shape(grid_id)
-        if grid_size == ():
-            return 1
-        else:
-            return int(np.prod(grid_size))
-
-    # Todo: Revise once we can work with georeferenced data in the CMF.
-    def get_grid_spacing(self, grid_id):
-        return np.array([1, 1], dtype='float32')
-
-    # Todo: Revise once we can work with georeferenced data in the CMF.
-    def get_grid_origin(self, grid_id):
-        return np.array([0.0, 0.0], dtype='float32')
+        return 1
 
     def get_grid_rank(self, var_id):
         """Rank of grid.
@@ -480,7 +462,7 @@ class BmiKuMethod( perma_base.PermafrostComponent ):
         int
             Rank of grid.
         """
-        return len(self.get_grid_shape(var_id))
+        return 0
 
     def save_grids(self):
         # Saves the grid values based on the prescribed ones in cfg file

--- a/permamodel/components/bmi_frost_number.py
+++ b/permamodel/components/bmi_frost_number.py
@@ -57,8 +57,9 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
             'time_units':         'years'}
 
         self._input_var_names = (
-            'atmosphere_bottom_air__temperature',
-            )
+            'atmosphere_bottom_air__time_min_of_temperature',
+            'atmosphere_bottom_air__time_max_of_temperature',
+        )
 
         self._output_var_names = (
             'frostnumber__air',            # Air Frost number
@@ -66,16 +67,20 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
             'frostnumber__stefan')        # Stefan Frost number
 
         self._var_name_map = {
-            'atmosphere_bottom_air__temperature':  'T_air_min',
-            'frostnumber__air':                    'air_frost_number',
-            'frostnumber__surface':                'surface_frost_number',
-            'frostnumber__stefan':                 'stefan_frost_number'}
+            'atmosphere_bottom_air__time_min_of_temperature': 'T_air_min',
+            'atmosphere_bottom_air__time_max_of_temperature': 'T_air_max',
+            'frostnumber__air': 'air_frost_number',
+            'frostnumber__surface': 'surface_frost_number',
+            'frostnumber__stefan': 'stefan_frost_number',
+        }
 
         self._var_units_map = {
-            'atmosphere_bottom_air__temperature':   'deg_C',
-            'frostnumber__air':                     '1',
-            'frostnumber__surface':                 '1',
-            'frostnumber__stefan':                  '1'}
+            'atmosphere_bottom_air__time_min_of_temperature': 'deg_C',
+            'atmosphere_bottom_air__time_max_of_temperature': 'deg_C',
+            'frostnumber__air': '1',
+            'frostnumber__surface': '1',
+            'frostnumber__stefan': '1',
+        }
 
     def initialize(self, cfg_file=None):
         """ this overwrites initialize() in PermafrostComponent """
@@ -113,10 +118,12 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
         self._values = {
             # These are the links to the model's variables and
             # should be consistent with _var_name_map
-            'atmosphere_bottom_air__temperature':    self._model.T_air_min,
+            'atmosphere_bottom_air__time_min_of_temperature': self._model.T_air_min,
+            'atmosphere_bottom_air__time_max_of_temperature': self._model.T_air_max,
             'frostnumber__air':         self._model.air_frost_number,
             'frostnumber__surface':     self._model.surface_frost_number,
-            'frostnumber__stefan':      self._model.stefan_frost_number}
+            'frostnumber__stefan':      self._model.stefan_frost_number,
+        }
 
     def get_attribute(self, att_name):
         try:
@@ -233,7 +240,11 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
 
     def set_value(self, var_name, new_var_values):
         """ BMI: allow external set-access to model variable """
-        self._values[var_name] = new_var_values
+        array = getattr(self._model, self._var_name_map[var_name])
+        array[int(self._model.year - self._model.start_year)] = new_var_values
+
+        # setattr(self._model, self._var_name_map[var_name], new_var_values)
+        # self._values[var_name] = new_var_values
 
     def set_value_at_indices(self, var_name, new_var_values, indices):
         """ BMI: allow external set-access to model array variable """
@@ -333,7 +344,7 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
         """
         return 1
 
-    def get_grid_rank(self, var_id):
+    def get_grid_rank(self, grid_id):
         """Rank of grid.
 
         Parameters

--- a/permamodel/components/bmi_frost_number.py
+++ b/permamodel/components/bmi_frost_number.py
@@ -317,12 +317,6 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
             if var_name in var_name_list:
                 return grid_id
 
-    def get_grid_shape(self, grid_id):
-        """Number of rows and columns of uniform rectilinear grid."""
-        var_name = self._grids[grid_id]
-        value = np.array(self.get_value_ref(var_name)).shape
-        return value
-
     def get_grid_size(self, grid_id):
         """Size of grid.
 
@@ -337,11 +331,7 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
             Size of grid.
 
         """
-        grid_size = self.get_grid_shape(grid_id)
-        if grid_size == ():
-            return 1
-        else:
-            return int(np.prod(grid_size))
+        return 1
 
     def get_grid_rank(self, var_id):
         """Rank of grid.
@@ -356,4 +346,4 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
         int
             Rank of grid.
         """
-        return len(self.get_grid_shape(var_id))
+        return 0

--- a/permamodel/components/bmi_frost_number.py
+++ b/permamodel/components/bmi_frost_number.py
@@ -241,7 +241,10 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
     def set_value(self, var_name, new_var_values):
         """ BMI: allow external set-access to model variable """
         array = getattr(self._model, self._var_name_map[var_name])
-        array[int(self._model.year - self._model.start_year)] = new_var_values
+        if len(array) == 1:
+            array[0] = new_var_values
+        else:
+            array[int(self._model.year - self._model.start_year) + 1] = new_var_values
 
         # setattr(self._model, self._var_name_map[var_name], new_var_values)
         # self._values[var_name] = new_var_values

--- a/permamodel/components/bmi_frost_number_Geo.py
+++ b/permamodel/components/bmi_frost_number_Geo.py
@@ -7,9 +7,9 @@
 from __future__ import print_function
 
 import numpy as np
-from permamodel.components import perma_base
-from permamodel.components import frost_number_Geo
-from nose.tools import (assert_in, assert_true)
+
+from permamodel.components import frost_number_Geo, perma_base
+
 
 class BmiFrostnumberGeoMethod(perma_base.PermafrostComponent):
     """ Implement the Nelson-Outcalt Frost numbers
@@ -125,11 +125,11 @@ class BmiFrostnumberGeoMethod(perma_base.PermafrostComponent):
         # Verify that all input and output variable names are in the
         # variable name and the units map
         for varname in self._input_var_names:
-            assert_in(varname, self._var_name_map)
-            assert_in(varname, self._var_units_map)
+            assert varname in self._var_name_map
+            assert varname in self._var_units_map
         for varname in self._output_var_names:
-            assert_in(varname, self._var_name_map)
-            assert_in(varname, self._var_units_map)
+            assert varname in self._var_name_map
+            assert varname in self._var_units_map
 
         # Set the names and types of the grids
         # Note: A single value is a uniform rectilinear grid of shape (1)
@@ -283,7 +283,7 @@ class BmiFrostnumberGeoMethod(perma_base.PermafrostComponent):
             return int(np.prod(grid_size))
 
     def get_grid_spacing(self, grid_id, out=None):
-        assert_true(grid_id < self.ngrids)
+        assert grid_id < self.ngrids
         var_name = self._grids[grid_id]
         if out is None:
             ndim = np.array(self.get_value_ref(var_name)).ndim

--- a/permamodel/tests/test_frost_number.py
+++ b/permamodel/tests/test_frost_number.py
@@ -5,11 +5,12 @@ test_frost_number.py
 from __future__ import print_function
 
 import os
+
+from pytest import approx
+
 from permamodel.components import frost_number
+
 from .. import examples_directory
-from nose.tools import (assert_equal, assert_greater_equal,
-                        assert_almost_equal, assert_raises,
-                        assert_true)
 
 # List of files to be removed after testing is complete
 # use files_to_remove.append(<filename>) to add to it
@@ -40,7 +41,7 @@ def test_end_year_before_start_year_error():
     fn.start_year = 2000
     fn.end_year = 1990
     fn.initialize_frostnumber_component()
-    assert_equal(fn.start_year, fn.end_year)
+    assert fn.start_year == fn.end_year
 
 def test_can_initialize_frostnumber_method_from_scalar_file():
     """ Test fn initialization from config file (scalar) """
@@ -56,8 +57,8 @@ def test_frostnumber_method_has_date_info():
     cfg_file = os.path.join(examples_directory,
                             'Frostnumber_example_scalar.cfg')
     fn.initialize(cfg_file=cfg_file)
-    assert_greater_equal(fn.year, 0)
-    assert_equal(fn.year, fn.start_year)
+    assert fn.year >= 0
+    assert fn.year == fn.start_year
 
 def test_can_initialize_frostnumber_method_from_timeseries_file():
     """ Test fn initialization from config file (time series) """
@@ -71,7 +72,7 @@ def test_frostnumber_method_calculates_fn():
     """ Test fn gets calculated """
     fn = frost_number.FrostnumberMethod()
     fn.initialize()
-    assert_almost_equal(fn.air_frost_number, 0.63267, places=3)
+    assert fn.air_frost_number == approx(0.6326749410343562)
 
 def test_frostnumber_method_calculates_exact_fn():
     """ Test fn gets calculated """
@@ -80,11 +81,11 @@ def test_frostnumber_method_calculates_exact_fn():
     fn.T_air_min = [5.0]
     fn.T_air_max = [15.0]
     fn.calculate_air_frost_number()
-    assert_almost_equal(fn.air_frost_number, 0.0, places=3)
+    assert fn.air_frost_number == approx(0.0)
     fn.T_air_min = [-25.0]
     fn.T_air_max = [-5.0]
     fn.calculate_air_frost_number()
-    assert_almost_equal(fn.air_frost_number, 1.0, places=3)
+    assert fn.air_frost_number == approx(1.0)
 
 def test_frostnumber_method_updates():
     """ Test fn update() """
@@ -93,8 +94,8 @@ def test_frostnumber_method_updates():
                             'Frostnumber_example_timeseries.cfg')
     fn.initialize(cfg_file=cfg_file)
     fn.update()
-    assert_equal(fn.year, 2001)
-    assert_almost_equal(fn.air_frost_number, 0.5, places=3)
+    assert fn.year == 2001
+    assert fn.air_frost_number == approx(0.5)
 
 def test_frostnumber_generates_output():
     """ Test fn generates output file """
@@ -105,7 +106,7 @@ def test_frostnumber_generates_output():
     fn.update()
     output_written = fn.write_output_to_file()
     if output_written:
-        assert_true(os.path.isfile(fn.fn_out_filename))
+        assert os.path.isfile(fn.fn_out_filename)
         files_to_remove.append(fn.fn_out_filename)
     else:
         print('Unable to test output to: {}'.format(fn.fn_out_filename))

--- a/permamodel/tests/test_frost_number_Geo.py
+++ b/permamodel/tests/test_frost_number_Geo.py
@@ -2,17 +2,15 @@
 test_frost_number_Geo.py
   tests of the Geo version of the frost_number component of permamodel
 """
+import datetime
+import os
+
+import numpy as np
+import pytest
 
 from permamodel.components import frost_number_Geo
-import os
-import numpy as np
-import datetime
-from .. import permamodel_directory, examples_directory
-from nose.tools import (assert_is_instance, assert_greater_equal,
-                        assert_less_equal, assert_almost_equal,
-                        assert_greater, assert_less, assert_in,
-                        assert_false, assert_true, assert_equal,
-                        assert_raises)
+
+from .. import examples_directory, permamodel_directory
 
 # List of files to be removed after testing is complete
 # use files_to_remove.append(<filename>) to add to it
@@ -34,27 +32,26 @@ def test_can_initialize_Geo_frostnumber_module():
 
 def test_Geo_frostnumber_has_default_config_file():
     fn_geo = frost_number_Geo.FrostnumberGeoMethod()
-    assert_true(fn_geo._config_filename is not None)
+    assert fn_geo._config_filename is not None
 
 def test_Geo_frostnumber_can_be_passed_config_filename():
     fn_geo = frost_number_Geo.FrostnumberGeoMethod(cfgfile="a file")
-    assert_true(fn_geo._config_filename == "a file")
+    assert fn_geo._config_filename == "a file"
 
 # Configuration from "Files" not supported for WMT version
 #def test_Geo_frostnumber_initializes_from_files_config_file():
 #    fn_geo = frost_number_Geo.FrostnumberGeoMethod(cfgfile=files_cfg_file)
-#    assert_true(os.path.isfile(fn_geo._config_filename))
+#    assert os.path.isfile(fn_geo._config_filename)
 #    fn_geo.initialize_frostnumberGeo_component()
-#    assert_true(fn_geo._grid_type == 'uniform rectilinear')
-#    assert_true(fn_geo._calc_surface_fn is not None)
-#    assert_true(fn_geo._calc_stefan_fn is not None)
-#    assert_in(fn_geo._dd_method, ('ObservedMinMax', 'MinJanMaxJul',
-#            'MonthlyAverages', 'DailyValues'))
+#    assert fn_geo._grid_type == 'uniform rectilinear'
+#    assert fn_geo._calc_surface_fn is not None
+#    assert fn_geo._calc_stefan_fn is not None
+#    assert fn_geo._dd_method in ('ObservedMinMax', 'MinJanMaxJul', 'MonthlyAverages', 'DailyValues')
 #    if fn_geo._dd_method == 'MinJanMaxJul':
-#        assert_equal(fn_geo.T_air_min.shape, fn_geo._grid_shape)
-#        assert_equal(fn_geo.T_air_max.shape, fn_geo._grid_shape)
+#        assert fn_geo.T_air_min.shape == fn_geo._grid_shape
+#        assert fn_geo.T_air_max.shape == fn_geo._grid_shape
 #        if fn_geo._using_Files:
-#            assert_true(fn_geo._temperature_dataset is not None)
+#            assert fn_geo._temperature_dataset is not None
 #
 #    fn_geo.finalize_frostnumber_Geo()
 #    files_to_remove.append(fn_geo.output_filename)
@@ -73,11 +70,11 @@ def test_Geo_frostnumber_initialize_datacube():
          'temperature_grid_data_3': '((7, 2), (17, 12), (23, 28))'}
     dates, cube = fn_geo.initialize_datacube('temperature', config_dict)
 
-    assert_in(datetime.date(1901,7,1), dates)  # second date
+    assert datetime.date(1901,7,1) in dates  # second date
 
-    assert_equal(cube[0, 0, 0], -10)  # very first value
-    assert_equal(cube[3, 2, 1], 28)   # very last value
-    assert_equal(cube[2, 1, 0], -17)   # 3rd date, 2nd set, 1st value
+    assert cube[0, 0, 0] == -10  # very first value
+    assert cube[3, 2, 1] == 28   # very last value
+    assert cube[2, 1, 0] == -17   # 3rd date, 2nd set, 1st value
 
 
 def test_Geo_frostnumber_get_datacube_slice():
@@ -96,35 +93,37 @@ def test_Geo_frostnumber_get_datacube_slice():
 
     test_date = datetime.date(1901, 2, 27)
     test_field = fn_geo.get_datacube_slice(test_date, cube, dates)
-    assert_equal(test_field[0, 0], -10)
-    assert_equal(test_field[1, 1], -15)
+    assert test_field[0, 0] == -10
+    assert test_field[1, 1] == -15
 
     test_date = datetime.date(1902, 3, 10)
     test_field = fn_geo.get_datacube_slice(test_date, cube, dates)
-    assert_equal(test_field[1, 0], -17)
-    assert_equal(test_field[2, 1], 8)
+    assert test_field[1, 0] == -17
+    assert test_field[2, 1] == 8
 
     test_date = datetime.date(1900, 3, 10)
-    assert_raises(ValueError, fn_geo.get_datacube_slice, test_date, cube, dates)
+    with pytest.raises(ValueError):
+        fn_geo.get_datacube_slice(test_date, cube, dates)
 
     test_date = datetime.date(1980, 3, 10)
-    assert_raises(ValueError, fn_geo.get_datacube_slice, test_date, cube, dates)
+    with pytest.raises(ValueError):
+        fn_geo.get_datacube_slice(test_date, cube, dates)
 
 
 def test_Geo_frostnumber_initializes_from_default_config_file():
     fn_geo = frost_number_Geo.FrostnumberGeoMethod()
-    assert_true(os.path.isfile(fn_geo._config_filename))
+    assert os.path.isfile(fn_geo._config_filename)
     fn_geo.initialize_frostnumberGeo_component()
-    assert_true(fn_geo._grid_type == 'uniform rectilinear')
-    assert_true(fn_geo._calc_surface_fn is not None)
-    assert_true(fn_geo._calc_stefan_fn is not None)
-    assert_in(fn_geo._dd_method, ('ObservedMinMax', 'MinJanMaxJul',
-            'MonthlyAverages', 'DailyValues'))
+    assert fn_geo._grid_type == 'uniform rectilinear'
+    assert fn_geo._calc_surface_fn is not None
+    assert fn_geo._calc_stefan_fn is not None
+    assert fn_geo._dd_method in ('ObservedMinMax', 'MinJanMaxJul',
+            'MonthlyAverages', 'DailyValues')
     if fn_geo._dd_method == 'MinJanMaxJul':
-        assert_equal(fn_geo.T_air_min.shape, fn_geo._grid_shape)
-        assert_equal(fn_geo.T_air_max.shape, fn_geo._grid_shape)
+        assert fn_geo.T_air_min.shape == fn_geo._grid_shape
+        assert fn_geo.T_air_max.shape == fn_geo._grid_shape
         if fn_geo._using_Files:
-            assert_true(fn_geo._temperature_dataset is not None)
+            assert fn_geo._temperature_dataset is not None
 
     fn_geo.finalize_frostnumber_Geo()
     files_to_remove.append(fn_geo.output_filename)
@@ -134,18 +133,16 @@ def test_Geo_frostnumber_can_compute_real_date_from_timestep():
     fn_geo.initialize_frostnumberGeo_component()
 
     # Timestep should be one year
-    assert_equal(fn_geo._timestep_duration, 1)
+    assert fn_geo._timestep_duration == 1
 
     # Model reference date should have timestep of zero
-    assert_equal(fn_geo.get_timestep_from_date(fn_geo._reference_date), 0)
+    assert fn_geo.get_timestep_from_date(fn_geo._reference_date) == 0
 
     # Timestep of first date should be first timestep
-    assert_equal(fn_geo._timestep_first,
-                 fn_geo.get_timestep_from_date(fn_geo._start_date))
+    assert fn_geo._timestep_first == fn_geo.get_timestep_from_date(fn_geo._start_date)
 
     # Last date should be date of last timestep
-    assert_equal(fn_geo._end_date,
-                 fn_geo.get_date_from_timestep(fn_geo._timestep_last))
+    assert fn_geo._end_date == fn_geo.get_date_from_timestep(fn_geo._timestep_last)
 
     fn_geo.finalize_frostnumber_Geo()
 
@@ -154,10 +151,10 @@ def test_Geo_frostnumber_can_return_temperature_field():
     fn_geo.initialize_frostnumberGeo_component()
 
     current_temperature_field = fn_geo.get_temperature_field()
-    assert_equal(current_temperature_field.shape, fn_geo._grid_shape)
+    assert current_temperature_field.shape == fn_geo._grid_shape
 
     bad_date_field = fn_geo.get_temperature_field(datetime.date(100, 1, 1))
-    assert_true(np.all(np.isnan(bad_date_field)))
+    assert np.all(np.isnan(bad_date_field))
 
     fn_geo.finalize_frostnumber_Geo()
 
@@ -167,13 +164,13 @@ def test_Geo_frostnumber_get_latest_min_max_months():
 
     this_date = datetime.date(1905, 1, 1)
     (mindate, maxdate) = fn_geo.get_min_and_max_dates(this_date)
-    assert_equal(mindate, datetime.date(1905, 1, 15))
-    assert_equal(maxdate, datetime.date(1904, 7, 15))
+    assert mindate == datetime.date(1905, 1, 15)
+    assert maxdate == datetime.date(1904, 7, 15)
 
     this_date = datetime.date(2004, 8, 1)
     (mindate, maxdate) = fn_geo.get_min_and_max_dates(this_date)
-    assert_equal(mindate, datetime.date(2004, 1, 15))
-    assert_equal(maxdate, datetime.date(2004, 7, 15))
+    assert mindate == datetime.date(2004, 1, 15)
+    assert maxdate == datetime.date(2004, 7, 15)
 
     fn_geo.finalize_frostnumber_Geo()
 
@@ -191,50 +188,50 @@ def test_Geo_frostnumber_compute_array_of_degree_days():
     # Test that we get NaN-filled arrays when no input vars available
     fn_geo.set_current_date_and_timestep_with_timestep(-100)
     fn_geo.get_input_vars()
-    assert_less(fn_geo._date_current, fn_geo._temperature_first_date)
+    assert fn_geo._date_current < fn_geo._temperature_first_date
     if fn_geo._dd_method == 'MinJanMaxJul':
         # A timestep out of bounds should yield nans for temp and dd
-        assert_true(np.all(np.isnan(fn_geo.T_air_min)))
-        assert_true(np.all(np.isnan(fn_geo.T_air_max)))
+        assert np.all(np.isnan(fn_geo.T_air_min))
+        assert np.all(np.isnan(fn_geo.T_air_max))
 
         # Calculating degree days on all NaNs yields all NaNs
         fn_geo.compute_degree_days()
-        assert_true(np.all(np.isnan(fn_geo.ddt)))
-        assert_true(np.all(np.isnan(fn_geo.ddf)))
+        assert np.all(np.isnan(fn_geo.ddt))
+        assert np.all(np.isnan(fn_geo.ddf))
 
         # Calculating air frost number on NaNs yields NaNs
         fn_geo.compute_air_frost_number_Geo()
-        assert_true(np.all(np.isnan(fn_geo.air_frost_number_Geo)))
+        assert np.all(np.isnan(fn_geo.air_frost_number_Geo))
 
     # Test that we get real values
     fn_geo.set_current_date_and_timestep_with_timestep(2)
     fn_geo.get_input_vars()
-    assert_greater_equal(fn_geo._date_current, fn_geo._temperature_first_date)
+    assert fn_geo._date_current >= fn_geo._temperature_first_date
     if fn_geo._dd_method == 'MinJanMaxJul':
         # The default should have no missing temperature values
-        assert_false(np.any(np.isnan(fn_geo.T_air_min)))
-        assert_false(np.any(np.isnan(fn_geo.T_air_max)))
+        assert not np.any(np.isnan(fn_geo.T_air_min))
+        assert not np.any(np.isnan(fn_geo.T_air_max))
         #fn_geo.T_air_min.tofile("Tairmin.dat")
         #fn_geo.T_air_max.tofile("Tairmax.dat")
 
         # Calculating degree days on all NaNs yields all NaNs
         fn_geo.compute_degree_days()
-        assert_false(np.any(np.isnan(fn_geo.ddt)))
-        assert_false(np.any(np.isnan(fn_geo.ddf)))
+        assert not np.any(np.isnan(fn_geo.ddt))
+        assert not np.any(np.isnan(fn_geo.ddf))
         #fn_geo.ddt.tofile("ddt.dat")
         #fn_geo.ddf.tofile("ddf.dat")
 
         # Calculating air frost number on NaNs yields NaNs
         fn_geo.compute_air_frost_number_Geo()
-        assert_false(np.any(np.isnan(fn_geo.air_frost_number_Geo)))
+        assert not np.any(np.isnan(fn_geo.air_frost_number_Geo))
         #fn_geo.air_frost_number_Geo.tofile("afn_geod.dat")
     fn_geo.finalize_frostnumber_Geo()
 
 def test_Geo_frostnumber_output_a_netcdf_file():
     fn_geo = frost_number_Geo.FrostnumberGeoMethod()
     fn_geo.initialize_frostnumberGeo_component()
-    assert_true(fn_geo.output_filename is not None)
-    assert_true(fn_geo.output_filename[-3:] == '.nc')
+    assert fn_geo.output_filename is not None
+    assert fn_geo.output_filename[-3:] == '.nc'
     fn_geo.initial_update()
     for t in range(0, 10):
         fn_geo.get_input_vars()
@@ -250,4 +247,3 @@ def test_Geo_frostnumber_update_until_timestep():
     fn_geo.initial_update()
     fn_geo.update_until_timestep(fn_geo._timestep_last)
     fn_geo.finalize()
-

--- a/permamodel/tests/test_frost_number_Geo_bmi.py
+++ b/permamodel/tests/test_frost_number_Geo_bmi.py
@@ -2,43 +2,39 @@
 test_frost_number_bmi.py
   tests of the frost_number component of permamodel using bmi API
 """
-
-from permamodel.components import frost_number_Geo
-from permamodel.components import bmi_frost_number_Geo
-from permamodel.components import perma_base
-from dateutil.relativedelta import relativedelta
-import os
-import numpy as np
-from .. import examples_directory
-from nose.tools import (assert_is_instance, assert_greater_equal,
-                        assert_less_equal, assert_almost_equal,
-                        assert_greater, assert_in, assert_true,
-                        assert_false, assert_equal, assert_raises,
-                        assert_not_equal)
-from numpy.testing import assert_array_equal
 import datetime
+import os
 
+import numpy as np
+import pytest
+from dateutil.relativedelta import relativedelta
+from pytest import approx
+
+from permamodel.components import bmi_frost_number_Geo, frost_number_Geo, perma_base
+
+from .. import examples_directory
 
 # Set the file names for the example cfg files
-config_filename = \
-        os.path.join(examples_directory,
-                     'FrostnumberGeo_Default.cfg')
+config_filename = os.path.join(examples_directory, "FrostnumberGeo_Default.cfg")
 
 # List of files to be removed after testing is complete
 # use files_to_remove.append(<filename>) to add to it
 files_to_remove = []
 
+
 def setup_module():
     """ Standard fixture called before any tests in this file are performed """
     pass
 
+
 def teardown_module():
     """ Standard fixture called after all tests in this file are performed """
     # If need to remove files that are created:
-    #for f in files_to_remove:
+    # for f in files_to_remove:
     #    if os.path.exists(f):
     #        os.remove(f)
     pass
+
 
 # ---------------------------------------------------
 # Tests that ensure we have bmi functionality
@@ -46,246 +42,284 @@ def teardown_module():
 # files are not closed.  This is done in the finalize() routine
 # which should therefore be called after every test
 # ---------------------------------------------------
-def test_frost_number_Geo_has_initialize():
+def test_frost_number_Geo_has_initialize(tmpdir):
     # Can we call an initialize function?
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    fng.initialize(cfg_file=config_filename)
-    fng.finalize()  # Must have this or get IOError later
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        fng.initialize(cfg_file=config_filename)
+        fng.finalize()  # Must have this or get IOError later
 
-def test_frost_number_initialize_sets_year():
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    fng.initialize(cfg_file=config_filename)
 
-    # Assert the values from the cfg file
-    assert_equal(fng._model._date_current.year, 1901)
-    fng.finalize()  # Must have this or get IOError later
+def test_frost_number_initialize_sets_year(tmpdir):
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        fng.initialize(cfg_file=config_filename)
 
-def test_frost_number_initialize_sets_air_min_and_max():
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    fng.initialize(cfg_file=config_filename)
+        # Assert the values from the cfg file
+        assert fng._model._date_current.year == 1901
+        fng.finalize()  # Must have this or get IOError later
 
-    # The temperature arrays are initialized to all NaNs
-    nan_array = np.zeros((3, 2), dtype=np.float32)
-    nan_array.fill(np.nan)
-    assert_array_equal(fng._model.T_air_min, nan_array)
-    assert_array_equal(fng._model.T_air_max, nan_array)
-    fng.finalize()  # Must have this or get IOError later
 
-def test_frost_number_update_increments_time():
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    fng.initialize()
-    fng.update()
+def test_frost_number_initialize_sets_air_min_and_max(tmpdir):
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        fng.initialize(cfg_file=config_filename)
 
-    assert_equal(fng._model._date_current,
-                 fng._model._start_date + \
-                 relativedelta(years=fng._model._timestep_duration))
-    fng.finalize()  # Must have this or get IOError later
+        # The temperature arrays are initialized to all NaNs
+        nan_array = np.zeros((3, 2), dtype=np.float32)
+        nan_array.fill(np.nan)
+        assert np.all(np.isnan(fng._model.T_air_min))  # == nan_array)
+        fng.finalize()  # Must have this or get IOError later
 
-def test_frost_number_update_changes_air_frost_number():
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    fng.initialize()
 
-    fng.update()
-    afn0 = fng._model.air_frost_number_Geo
-    fng.update_until(1.0)
-    afn1 = fng._model.air_frost_number_Geo
-    try:
-        # If this is none, then the first array was all NaNs
-        assert_true(assert_array_equal(afn0, afn1) is None)
-    except AssertionError:
-        # If this is raised, then the arrays are different, which is nood
-        pass
-    fng.finalize()  # Must have this or get IOError later
-
-def test_frost_number_get_current_time_returns_scalar():
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    fng.initialize()
-    current_time = fng.get_current_time()
-    assert_true(isinstance(current_time, float) \
-                or isinstance(current_time, int))
-    fng.finalize()  # Must have this or get IOError later
-
-def test_frost_number_get_end_time_returns_scalar():
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    fng.initialize()
-    end_time = fng.get_end_time()
-    assert(isinstance(end_time, float) \
-           or isinstance(end_time, int))
-    fng.finalize()  # Must have this or get IOError later
-
-def test_frost_number_implements_update_until():
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    fng.initialize()
-
-    fng.update_until(fng.get_end_time())
-    assert_true(fng._model._date_current, fng._model._end_date)
-
-    fng.finalize()  # Must have this or get IOError later
-
-def test_FNGeo_computes_default_values():
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    fng.initialize()
-    for n in range(5):
-        if (fng._model.T_air_min[0, 0] + fng._model.T_air_max[0, 0]) == 0:
-            assert_equal(fng._values['frostnumber__air'][0, 0], 0.5)
-        if (fng._model.T_air_min[0, 0] <= 0.0) and \
-           (fng._model.T_air_max[0, 0] <= 0.0):
-            assert_equal(fng._values['frostnumber__air'][0, 0], 1.0)
-        if (fng._model.T_air_min[0, 0] > 0.0) and \
-           (fng._model.T_air_max[0, 0] > 0.0):
-            assert_equal(fng._values['frostnumber__air'][0, 0], 0.0)
-        #print("FNGeo frostnumber__air: %d" % n)
-        #print(fng._model.T_air_min)
-        #print(fng._model.T_air_max)
-        #print(fng._values['frostnumber__air'])
+def test_frost_number_update_increments_time(tmpdir):
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        fng.initialize()
         fng.update()
-    fng.finalize()  # Must have this or get IOError later
 
-def test_FNGeo_get_attribute():
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    fng.initialize()
-    # Check an attribute that exists
-    this_att = fng.get_attribute('time_units')
-    assert_equal(this_att, 'years')
+        assert fng._model._date_current == fng._model._start_date + relativedelta(
+            years=fng._model._timestep_duration
+        )
+        fng.finalize()  # Must have this or get IOError later
 
-    # Check an attribute that doesn't exist
-    assert_raises(KeyError, fng.get_attribute, 'not_an_attribute')
 
-    fng.finalize()  # Must have this or get IOError later
+def test_frost_number_update_changes_air_frost_number(tmpdir):
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        fng.initialize()
 
-def test_FNGeo_get_input_var_names():
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    fng.initialize()
-    assert_in('atmosphere_bottom_air__temperature', fng.get_input_var_names())
+        afn0 = fng._model.air_frost_number_Geo.copy()
+        fng.update()
+        afn1 = fng._model.air_frost_number_Geo.copy()
+        assert np.any(afn0 != afn1)
+        fng.update_until(1.0)
+        afn2 = fng._model.air_frost_number_Geo.copy()
+        assert np.all(afn1 == afn2)
 
-    fng.finalize()  # Must have this or get IOError later
+        fng.finalize()  # Must have this or get IOError later
 
-def test_FNGeo_get_output_var_names():
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    fng.initialize()
-    assert_in('frostnumber__air', fng.get_output_var_names())
 
-    fng.finalize()  # Must have this or get IOError later
+def test_frost_number_get_current_time_returns_scalar(tmpdir):
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        fng.initialize()
+        current_time = fng.get_current_time()
+        assert isinstance(current_time, (float, int))
+        fng.finalize()  # Must have this or get IOError later
 
-def test_FNGeo_get_set_value():
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    fng.initialize()
 
-    airtempval = fng.get_value('atmosphere_bottom_air__temperature')
-    airtempnew = 123 * np.ones_like(airtempval)
-    fng.set_value('atmosphere_bottom_air__temperature', airtempnew)
-    assert_raises(AssertionError, assert_array_equal, airtempval, airtempnew)
+def test_frost_number_get_end_time_returns_scalar(tmpdir):
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        fng.initialize()
+        end_time = fng.get_end_time()
+        assert isinstance(end_time, float) or isinstance(end_time, int)
+        fng.finalize()  # Must have this or get IOError later
 
-    fng.finalize()  # Must have this or get IOError later
 
-def test_FNGeo_get_grid_shape():
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    fng.initialize()
+def test_frost_number_implements_update_until(tmpdir):
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        fng.initialize()
 
-    airtemp_gridid = fng.get_var_grid('atmosphere_bottom_air__temperature')
-    assert_equal((3, 2), fng.get_grid_shape(airtemp_gridid))
+        fng.update_until(fng.get_end_time())
+        assert fng._model._date_current == fng._model._end_date
 
-    fng.finalize()  # Must have this or get IOError later
+        fng.finalize()  # Must have this or get IOError later
 
-def test_FNGeo_get_grid_size():
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    fng.initialize()
 
-    airtemp_gridid = fng.get_var_grid('atmosphere_bottom_air__temperature')
-    assert_equal(6, fng.get_grid_size(airtemp_gridid))
+def test_FNGeo_computes_default_values(tmpdir):
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        fng.initialize()
+        for n in range(5):
+            if (fng._model.T_air_min[0, 0] + fng._model.T_air_max[0, 0]) == 0:
+                assert fng._values["frostnumber__air"][0, 0] == 0.5
+            if (fng._model.T_air_min[0, 0] <= 0.0) and (
+                fng._model.T_air_max[0, 0] <= 0.0
+            ):
+                assert fng._values["frostnumber__air"][0, 0] == 1.0
+            if (fng._model.T_air_min[0, 0] > 0.0) and (
+                fng._model.T_air_max[0, 0] > 0.0
+            ):
+                assert fng._values["frostnumber__air"][0, 0] == 0.0
+            # print("FNGeo frostnumber__air: %d" % n)
+            # print(fng._model.T_air_min)
+            # print(fng._model.T_air_max)
+            # print(fng._values['frostnumber__air'])
+            fng.update()
+        fng.finalize()  # Must have this or get IOError later
 
-    fng.finalize()  # Must have this or get IOError later
 
-def test_FNGeo_get_grid_spacing():
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    fng.initialize()
+def test_FNGeo_get_attribute(tmpdir):
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        fng.initialize()
+        # Check an attribute that exists
+        this_att = fng.get_attribute("time_units")
+        assert this_att == "years"
 
-    airtemp_gridid = fng.get_var_grid('atmosphere_bottom_air__temperature')
-    assert_array_equal(
-        np.array([1.0, 1.0]),
-        fng.get_grid_spacing(airtemp_gridid))
+        # Check an attribute that doesn't exist
+        with pytest.raises(KeyError):
+            fng.get_attribute("not_an_attribute")
 
-    fng.finalize()  # Must have this or get IOError later
+        fng.finalize()  # Must have this or get IOError later
 
-def test_FNGeo_jan_and_jul_temperatures_are_grids():
+
+def test_FNGeo_get_input_var_names(tmpdir):
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        fng.initialize()
+        assert "atmosphere_bottom_air__temperature" in fng.get_input_var_names()
+
+        fng.finalize()  # Must have this or get IOError later
+
+
+def test_FNGeo_get_output_var_names(tmpdir):
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        fng.initialize()
+        assert "frostnumber__air" in fng.get_output_var_names()
+
+        fng.finalize()  # Must have this or get IOError later
+
+
+def test_FNGeo_get_set_value(tmpdir):
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        fng.initialize()
+
+        airtempval = fng.get_value("atmosphere_bottom_air__temperature")
+        airtempnew = 123 * np.ones_like(airtempval)
+        fng.set_value("atmosphere_bottom_air__temperature", airtempnew)
+        assert not np.all(airtempval == approx(airtempnew))
+
+        fng.finalize()  # Must have this or get IOError later
+
+
+def test_FNGeo_get_grid_shape(tmpdir):
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        fng.initialize()
+
+        airtemp_gridid = fng.get_var_grid("atmosphere_bottom_air__temperature")
+        assert (3, 2) == fng.get_grid_shape(airtemp_gridid)
+
+        fng.finalize()  # Must have this or get IOError later
+
+
+def test_FNGeo_get_grid_size(tmpdir):
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        fng.initialize()
+
+        airtemp_gridid = fng.get_var_grid("atmosphere_bottom_air__temperature")
+        assert fng.get_grid_size(airtemp_gridid) == 6
+
+        fng.finalize()  # Must have this or get IOError later
+
+
+def test_FNGeo_get_grid_spacing(tmpdir):
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        fng.initialize()
+
+        airtemp_gridid = fng.get_var_grid("atmosphere_bottom_air__temperature")
+        assert np.all(np.array([1.0, 1.0]) == fng.get_grid_spacing(airtemp_gridid))
+
+        fng.finalize()  # Must have this or get IOError later
+
+
+def test_FNGeo_jan_and_jul_temperatures_are_grids(tmpdir):
     """ Test that FNGeo BMI has input variables for jan and jul data """
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    fng.initialize()
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        fng.initialize()
 
-    airtemp_gridid = fng.get_var_grid('atmosphere_bottom_air__temperature')
-    jan_airtemp_gridid = \
-            fng.get_var_grid('atmosphere_bottom_air__temperature_mean_jan')
-    assert_true(jan_airtemp_gridid is not None)
-    jul_airtemp_gridid = \
-            fng.get_var_grid('atmosphere_bottom_air__temperature_mean_jul')
-    assert_true(jul_airtemp_gridid is not None)
+        airtemp_gridid = fng.get_var_grid("atmosphere_bottom_air__temperature")
+        jan_airtemp_gridid = fng.get_var_grid(
+            "atmosphere_bottom_air__temperature_mean_jan"
+        )
+        assert jan_airtemp_gridid is not None
+        jul_airtemp_gridid = fng.get_var_grid(
+            "atmosphere_bottom_air__temperature_mean_jul"
+        )
+        assert jul_airtemp_gridid is not None
 
-    fng.finalize()  # Must have this or get IOError later
+        fng.finalize()  # Must have this or get IOError later
 
-def test_FNGeo_can_set_current_and_jan_temperatures():
+
+def test_FNGeo_can_set_current_and_jan_temperatures(tmpdir):
     """ Test that FNGeo BMI can set jan temperature field """
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    fng.initialize()
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        fng.initialize()
 
-    airtemp_values = fng.get_value('atmosphere_bottom_air__temperature')
-    airtemp_values = np.ones_like(airtemp_values)
-    fng.set_value('atmosphere_bottom_air__temperature', airtemp_values)
+        airtemp_values = fng.get_value("atmosphere_bottom_air__temperature")
+        airtemp_values = np.ones_like(airtemp_values)
+        fng.set_value("atmosphere_bottom_air__temperature", airtemp_values)
 
-    jan_airtemp_values = \
-        fng.get_value('atmosphere_bottom_air__temperature_mean_jan')
-    jan_airtemp_values = np.ones_like(jan_airtemp_values)
-    fng.set_value('atmosphere_bottom_air__temperature_mean_jan',
-                  jan_airtemp_values)
-    assert_array_equal(
-        fng.get_value('atmosphere_bottom_air__temperature'),
-        fng.get_value('atmosphere_bottom_air__temperature_mean_jan'))
+        jan_airtemp_values = fng.get_value(
+            "atmosphere_bottom_air__temperature_mean_jan"
+        )
+        jan_airtemp_values = np.ones_like(jan_airtemp_values)
+        fng.set_value("atmosphere_bottom_air__temperature_mean_jan", jan_airtemp_values)
+        assert np.all(
+            fng.get_value("atmosphere_bottom_air__temperature")
+            == fng.get_value("atmosphere_bottom_air__temperature_mean_jan")
+        )
 
-    fng.finalize()  # Must have this or get IOError later
+        fng.finalize()  # Must have this or get IOError later
 
-def test_FNGeo_update_zero_fraction_does_not_change_time():
+
+def test_FNGeo_update_zero_fraction_does_not_change_time(tmpdir):
     """ Test that running update_frac(0) does not change the time """
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    fng.initialize()
-    init_time = fng.get_current_time()
-    fng.update_frac(0)
-    plus_zero_time = fng.get_current_time()
-    assert_equal(init_time, plus_zero_time)
-    fng.update()
-    one_update_time = fng.get_current_time()
-    assert_not_equal(init_time, one_update_time)
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        fng.initialize()
+        init_time = fng.get_current_time()
+        fng.update_frac(0)
+        plus_zero_time = fng.get_current_time()
+        assert init_time == plus_zero_time
+        fng.update()
+        one_update_time = fng.get_current_time()
+        assert not np.all(init_time == one_update_time)
 
-    fng.finalize()  # Must have this or get IOError later
+        fng.finalize()  # Must have this or get IOError later
 
-def test_FNGeo_simulate_WMT_run():
+
+def test_FNGeo_simulate_WMT_run(tmpdir):
     """ Test that we can set values as if running in WMT """
-    fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
-    wmt_cfg_file = os.path.join(examples_directory, "FNGeo_WMT_testing.cfg")
-    fng.initialize(wmt_cfg_file)
-    assert_equal(fng._name, "Permamodel FrostnumberGeo Component")
+    with tmpdir.as_cwd():
+        fng = bmi_frost_number_Geo.BmiFrostnumberGeoMethod()
+        wmt_cfg_file = os.path.join(examples_directory, "FNGeo_WMT_testing.cfg")
+        fng.initialize(wmt_cfg_file)
+        assert fng._name == "Permamodel FrostnumberGeo Component"
 
-    # Until set, e.g. by WMT with cru values, all vals are NaN
-    # Note: these are actually setting references to the underlying
-    #       model arrays!
-    airtemp_values = fng.get_value('atmosphere_bottom_air__temperature')
-    jan_airtemp_values = \
-        fng.get_value('atmosphere_bottom_air__temperature_mean_jan')
-    jul_airtemp_values = \
-        fng.get_value('atmosphere_bottom_air__temperature_mean_jul')
+        # Until set, e.g. by WMT with cru values, all vals are NaN
+        # Note: these are actually setting references to the underlying
+        #       model arrays!
+        airtemp_values = fng.get_value("atmosphere_bottom_air__temperature")
+        jan_airtemp_values = fng.get_value(
+            "atmosphere_bottom_air__temperature_mean_jan"
+        )
+        jul_airtemp_values = fng.get_value(
+            "atmosphere_bottom_air__temperature_mean_jul"
+        )
 
-    # In WMT mode, must set monthly temperature values, then run update_frac(0)
-    #   to get valid values in frost number array
-    # use January as 'coldest'
-    # use July as 'warmest'
-    airtemps_of_one = np.ones_like(airtemp_values)
-    jan_airtemp_values[:] = -10.0 * airtemps_of_one
-    jul_airtemp_values[:] = 10.0 * airtemps_of_one
-    fng.set_value('atmosphere_bottom_air__temperature_mean_jan',
-                  jan_airtemp_values)
-    fng.set_value('atmosphere_bottom_air__temperature_mean_jul',
-                  jul_airtemp_values)
-    fng.update_frac(0)
-    airfn_values = fng.get_value('frostnumber__air')
+        # In WMT mode, must set monthly temperature values, then run update_frac(0)
+        #   to get valid values in frost number array
+        # use January as 'coldest'
+        # use July as 'warmest'
+        airtemps_of_one = np.ones_like(airtemp_values)
+        jan_airtemp_values[:] = -10.0 * airtemps_of_one
+        jul_airtemp_values[:] = 10.0 * airtemps_of_one
+        fng.set_value("atmosphere_bottom_air__temperature_mean_jan", jan_airtemp_values)
+        fng.set_value("atmosphere_bottom_air__temperature_mean_jul", jul_airtemp_values)
+        fng.update_frac(0)
+        airfn_values = fng.get_value("frostnumber__air")
 
-    assert_array_equal(0.5 * airtemps_of_one, airfn_values)
+        assert np.all(0.5 * airtemps_of_one == airfn_values)
 
-    fng.finalize()  # Must have this or get IOError later
+        fng.finalize()  # Must have this or get IOError later

--- a/permamodel/tests/test_frost_number_bmi.py
+++ b/permamodel/tests/test_frost_number_bmi.py
@@ -2,14 +2,12 @@
 test_frost_number_bmi.py
   tests of the frost_number component of permamodel using bmi API
 """
-
 import os
-from permamodel.components import bmi_frost_number
-from permamodel import examples_directory
-from nose.tools import (assert_is_instance, assert_raises,
-                        assert_true, assert_in,
-                        assert_false, assert_equal)
 
+import pytest
+
+from permamodel import examples_directory
+from permamodel.components import bmi_frost_number
 
 # Set the file names for the example cfg files
 onesite_oneyear_filename = \
@@ -39,7 +37,7 @@ def teardown_module():
 def test_can_initialize_bmi_frost_number_module():
     """ Test that the BMI frost number module can be initialized """
     fn = bmi_frost_number.BmiFrostnumberMethod
-    assert_true(fn is not None)
+    assert fn is not None
 
 def test_frost_number_has_initialize():
     """ Test that the BMI frost number module has initialize() """
@@ -52,7 +50,7 @@ def test_frost_number_initialize_sets_year():
     fn.initialize(cfg_file=onesite_oneyear_filename)
 
     # Assert the values from the cfg file
-    assert_equal(fn.model.year, 2000)
+    assert fn.model.year == 2000
 
 def test_frost_number_initialize_sets_air_min_and_max():
     """ Verify initialied values """
@@ -60,8 +58,8 @@ def test_frost_number_initialize_sets_air_min_and_max():
     fn.initialize(cfg_file=onesite_oneyear_filename)
 
     # Assert the values from the cfg file
-    assert_equal(fn.model.T_air_min, -20.0)
-    assert_equal(fn.model.T_air_max, 10.0)
+    assert fn.model.T_air_min == -20.0
+    assert fn.model.T_air_max == 10.0
 
 def test_frost_number_update_increments_year():
     """ Test update increments time """
@@ -69,8 +67,8 @@ def test_frost_number_update_increments_year():
     fn.initialize(cfg_file=onesite_multiyear_filename)
 
     fn.update()
-    assert_equal(fn.model.year, fn.model.start_year + fn.model.dt)
-    assert_false(fn.model.year == fn.model.start_year)
+    assert fn.model.year == fn.model.start_year + fn.model.dt
+    assert fn.model.year != fn.model.start_year
 
 def test_frost_number_update_changes_air_frost_number():
     """ Test that value changes with update """
@@ -81,7 +79,7 @@ def test_frost_number_update_changes_air_frost_number():
     afn0 = fn.model.air_frost_number
     fn.update()
     afn1 = fn.model.air_frost_number
-    assert_false(afn0 == afn1)
+    assert afn0 != afn1
 
 def test_frost_number_runs_several_years():
     """ Test that frostnumber advances over several years """
@@ -91,12 +89,12 @@ def test_frost_number_runs_several_years():
     while fn.model.year < fn.model.end_year:
         fn.update()
 
-    assert_true(fn.model.output is not None)
+    assert fn.model.output is not None
 
     # Ensure that each year exists in the output dictionary
     year = fn.model.start_year
     while year < fn.model.end_year:
-        assert_true(year in fn.model.output.keys())
+        assert year in fn.model.output.keys()
         year += 1
 
 def test_frost_number_implements_update_until():
@@ -119,24 +117,25 @@ def test_frost_number_get_current_time_returns_scalar_float():
     fn = bmi_frost_number.BmiFrostnumberMethod()
     fn.initialize(cfg_file=onesite_multiyear_filename)
     current_time = fn.get_current_time()
-    assert_is_instance(current_time, float)
+    assert isinstance(current_time, float)
 
 def test_frost_number_get_end_time_returns_scalar_float():
     """ Test that end time is floating point """
     fn = bmi_frost_number.BmiFrostnumberMethod()
     fn.initialize(cfg_file=onesite_multiyear_filename)
     end_time = fn.get_end_time()
-    assert_is_instance(end_time, float)
+    assert isinstance(end_time, float)
 
 def test_frostnumber_get_attribute():
     fn = bmi_frost_number.BmiFrostnumberMethod()
     fn.initialize(cfg_file=onesite_multiyear_filename)
     # Check an attribute that exists
     this_att = fn.get_attribute('time_units')
-    assert_equal(this_att, 'years')
+    assert this_att == 'years'
 
     # Check an attribute that doesn't exist
-    assert_raises(KeyError, fn.get_attribute, 'not_an_attribute')
+    with pytest.raises(KeyError):
+        fn.get_attribute('not_an_attribute')
 
 def test_frostnumber_update():
     fn = bmi_frost_number.BmiFrostnumberMethod()
@@ -151,24 +150,19 @@ def test_frostnumber_update_frac():
 def test_bmi_fn_get_input_var_names():
     fn = bmi_frost_number.BmiFrostnumberMethod()
     fn.initialize(cfg_file=onesite_multiyear_filename)
-    assert_in('atmosphere_bottom_air__temperature',
-              fn.get_input_var_names())
+    assert 'atmosphere_bottom_air__time_min_of_temperature' in fn.get_input_var_names()
 
 def test_bmi_fn_get_output_var_names():
     fn = bmi_frost_number.BmiFrostnumberMethod()
     fn.initialize(cfg_file=onesite_multiyear_filename)
-    assert_in('frostnumber__air',
-              fn.get_output_var_names())
+    assert 'frostnumber__air' in fn.get_output_var_names()
 
 def test_bmi_fn_get_var_name():
     fn = bmi_frost_number.BmiFrostnumberMethod()
     fn.initialize(cfg_file=onesite_multiyear_filename)
-    assert_in('air_frost_number',
-              fn.get_var_name('frostnumber__air'))
+    assert 'air_frost_number' in fn.get_var_name('frostnumber__air')
 
 def test_bmi_fn_get_var_units():
     fn = bmi_frost_number.BmiFrostnumberMethod()
     fn.initialize(cfg_file=onesite_multiyear_filename)
-    assert_in('deg',
-              fn.get_var_units('atmosphere_bottom_air__temperature'))
-
+    assert 'deg' in fn.get_var_units('atmosphere_bottom_air__time_min_of_temperature')

--- a/permamodel/tests/test_package_directories.py
+++ b/permamodel/tests/test_package_directories.py
@@ -1,38 +1,37 @@
 """Tests directories set in the permamodel package definition file."""
 
 import os
-from nose.tools import assert_true
-from .. import (permamodel_directory, data_directory,
-                examples_directory, tests_directory)
+
+from .. import data_directory, examples_directory, permamodel_directory, tests_directory
 
 
 def test_permamodel_directory_is_set():
-    assert(permamodel_directory is not None)
+    assert permamodel_directory is not None
 
 
 def test_data_directory_is_set():
-    assert(data_directory is not None)
+    assert data_directory is not None
 
 
 def test_examples_directory_is_set():
-    assert(examples_directory is not None)
+    assert examples_directory is not None
 
 
 def test_tests_directory_is_set():
-    assert(tests_directory is not None)
+    assert tests_directory is not None
 
 
 def test_permamodel_directory_exists():
-    assert_true(os.path.isdir(permamodel_directory))
+    assert os.path.isdir(permamodel_directory)
 
 
 def test_data_directory_exists():
-    assert_true(os.path.isdir(data_directory))
+    assert os.path.isdir(data_directory)
 
 
 def test_examples_directory_exists():
-    assert_true(os.path.isdir(examples_directory))
+    assert os.path.isdir(examples_directory)
 
 
 def test_tests_directory_exists():
-    assert_true(os.path.isdir(tests_directory))
+    assert os.path.isdir(tests_directory)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,14 @@
+[tool:pytest]
+minversion = 3.0
+testpaths = permamodel
+norecursedirs = .* *.egg* build dist examples
+addopts =
+    --ignore setup.py
+    --tb native
+    --strict
+    --durations 16
+    --doctest-modules
+doctest_optionflags =
+    NORMALIZE_WHITESPACE
+    IGNORE_EXCEPTION_DETAIL
+    ALLOW_UNICODE

--- a/setup.py
+++ b/setup.py
@@ -2,17 +2,22 @@
 from setuptools import setup, find_packages
 
 
-setup(name='permamodel',
-      version='0.1.2',
-      author='Elchin Jafarov and Scott Stewart',
-      author_email='james.stewart@colorado.edu',
-      description='Permamodel',
-      long_description=open('README.md').read(),
-      packages=find_packages(),
-      #install_requires=('numpy', 'nose', 'gdal', 'pyproj'),
-      install_requires=('affine', 'netCDF4', 'scipy', 'numpy', 'nose',
-                        'pyyaml', 'python-dateutil'),
-      package_data={'': ['examples/*.cfg',
-                         'examples/*.dat',
-                         'data/*']}
+setup(
+    name="permamodel",
+    version="0.1.2",
+    author="Elchin Jafarov and Scott Stewart",
+    author_email="james.stewart@colorado.edu",
+    description="Permamodel",
+    long_description=open("README.md").read(),
+    packages=find_packages(),
+    # install_requires=('numpy', 'gdal', 'pyproj'),
+    install_requires=(
+        "affine",
+        "netCDF4",
+        "scipy",
+        "numpy",
+        "pyyaml",
+        "python-dateutil",
+    ),
+    package_data={"": ["examples/*.cfg", "examples/*.dat", "data/*"]},
 )


### PR DESCRIPTION
This pull request changes (fixes?) the behavior of `KuMethod` and `FrostNumberMethod` so that the max and min air temperatures can be set after the components have been initialized. Previously `atmosphere_bottom_air__temperature` was listed in *input_var_names* but it couldn't actually be changed after the component was initialized so it wasn't actually an input var.

* Added `atmosphere_bottom_air__time_max_of_temperature` and `atmosphere_bottom_air__time_min_of_temperature` (`T_air_max`, `T_air_min`) as input var names.
* Removed `atmosphere_bottom_air__temperature`. Although it's a valid name, it wasn't the correct name for either `T_air_min` or `T_air_max`.
* Changed `frost_number.py` so that `T_air_min` and `T_air_max` can be scalars or time series independently of one another.
* Changed components so that they can update for more than one year - even if either `T_air_min` or `T_air_max` are scalars.
* Changed so that `T_air_min` and `T_air_max` can be updated after the components have been initialized.
* Removed dependency on the deprecated `nose` package. Use `pytest` instead.

Allowing the min and max air temperatures to be settable dynamically after the components have been initialized removes the need for them to be set as *Time Series* in the config file. This is perhaps functionality that should be removed in the future. The generation of these time series seems like something that should be separated from the components and handled externally by another component. Removing this from all the components would greatly simply the code as well as making the components more flexible.