### PR TITLE
Use nox to build and test project

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,8 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: psf/black@stable
+
+      - uses: conda-incubator/setup-miniconda@v2
         with:
-          options: "--check --verbose --diff"
-          src: "permamodel"
+          miniforge-version: latest
+          python-version: 3.11
+          auto-activate-base: false
+
+      - name: Install nox
+        run: pip install nox
+
+      - name: Format code
+        run: nox -s format -- --check --verbose --diff

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Test
         run: |
-          nox -s test -- --cov=permamodel --cov-report=xml:./coverage.xml --cov-config=./setup.cfg -vvv --python ${{ matrix.python-version }}
+          nox -s test --python ${{ matrix.python-version }} -- --cov=permamodel --cov-report=xml:./coverage.xml --cov-config=./setup.cfg -vvv
 
       - name: Coveralls
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Test
         run: |
-          nox -s test -- --cov=permamodel --cov-report=xml:./coverage.xml --cov-config=./setup.cfg -vvv
+          nox -s test -- --cov=permamodel --cov-report=xml:./coverage.xml --cov-config=./setup.cfg -vvv --python ${{ matrix.python-version }}
 
       - name: Coveralls
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,27 +28,17 @@ jobs:
           miniforge-version: latest
           python-version: ${{ matrix.python-version }}
 
-      - name: Install package and testing dependencies
-        run: |
-          mamba install --file requirements.txt
-          mamba install pytest pytest-cov coveralls
-
       - name: Show conda installation info
         run: |
           mamba info
           mamba list
 
-      - name: Install package
-        run: pip install -e .
+      - name: Install package and nox
+        run: pip install -e .[dev]
 
       - name: Test
         run: |
-          pytest --cov=permamodel --cov-report=xml:./coverage.xml --cov-config=./setup.cfg -vvv
-
-      # - name: Test BMI
-      #   if: ${{ matrix.python-version == '3.9' }}  # stuck at py39 pending pymt update
-      #   run: |
-      #     bmi-test bmi_topography:BmiTopography --config-file=./examples/config.yaml --root-dir=./examples -vvv
+          nox -s test -- --cov=permamodel --cov-report=xml:./coverage.xml --cov-config=./setup.cfg -vvv
 
       - name: Coveralls
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,103 @@
+import os
+import pathlib
+import shutil
+from itertools import chain
+
+import nox
+
+PROJECT = "permamodel"
+HERE = pathlib.Path(__file__)
+ROOT = HERE.parent
+PATHS = [PROJECT + "/components", PROJECT + "/tests", HERE.name]
+PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
+
+
+@nox.session(python=PYTHON_VERSIONS)
+def test(session: nox.Session) -> None:
+    """Run the tests."""
+    session.install(".[testing]")
+    args = session.posargs or ["--cov", "--cov-report=term", "-vvv"]
+    session.run("pytest", *args)
+
+
+@nox.session
+def format(session: nox.Session) -> None:
+    """Clean lint and assert style."""
+    session.install(".[dev]")
+
+    if session.posargs:
+        black_args = session.posargs
+    else:
+        black_args = []
+
+    session.run("black", *black_args, *PATHS)
+    session.run("isort", *PATHS)
+    session.run("flake8", *PATHS)
+
+
+@nox.session
+def build(session: nox.Session) -> None:
+    """Build source and binary distributions."""
+    session.install(".[build]")
+    session.run("python", "-m", "build")
+
+
+@nox.session
+def release(session):
+    """Tag, build, and publish a new release to PyPI."""
+    session.install(".[build]")
+    session.run("fullrelease")
+
+
+@nox.session(name="testpypi")
+def publish_testpypi(session):
+    """Upload package to TestPyPI."""
+    build(session)
+    session.run("twine", "check", "dist/*")
+    session.run(
+        "twine",
+        "upload",
+        "--skip-existing",
+        "--repository-url",
+        "https://test.pypi.org/legacy/",
+        "dist/*",
+    )
+
+
+@nox.session(name="pypi")
+def publish_pypi(session):
+    """Upload package to PyPI."""
+    build(session)
+    session.run("twine", "check", "dist/*")
+    session.run(
+        "twine",
+        "upload",
+        "--skip-existing",
+        "--repository-url",
+        "https://upload.pypi.org/legacy/",
+        "dist/*",
+    )
+
+
+@nox.session(python=False)
+def clean(session):
+    """Remove virtual environments, build files, and caches."""
+    shutil.rmtree("build", ignore_errors=True)
+    shutil.rmtree("dist", ignore_errors=True)
+    shutil.rmtree(f"{PROJECT}.egg-info", ignore_errors=True)
+    shutil.rmtree(".pytest_cache", ignore_errors=True)
+    shutil.rmtree(".venv", ignore_errors=True)
+    if os.path.exists(".coverage"):
+        os.remove(".coverage")
+    for p in chain(ROOT.rglob("*.py[co]"), ROOT.rglob("__pycache__")):
+        if p.is_dir():
+            p.rmdir()
+        else:
+            p.unlink()
+
+
+@nox.session(python=False)
+def nuke(session):
+    """Clean and also remove the .nox directory."""
+    clean(session)
+    shutil.rmtree(".nox", ignore_errors=True)

--- a/permamodel/components/frost_number_Geo.py
+++ b/permamodel/components/frost_number_Geo.py
@@ -14,7 +14,6 @@ from dateutil.relativedelta import relativedelta
 from netCDF4 import Dataset
 
 from permamodel import data_directory, examples_directory
-# import yaml  # Used if yaml-style imports are used instead of Topoflow-like
 from permamodel.components import perma_base
 
 default_frostnumberGeo_config_filename = "FrostnumberGeo_Default.cfg"

--- a/permamodel/components/frost_number_Geo.py
+++ b/permamodel/components/frost_number_Geo.py
@@ -14,7 +14,6 @@ from dateutil.relativedelta import relativedelta
 from netCDF4 import Dataset
 
 from permamodel import data_directory, examples_directory
-
 # import yaml  # Used if yaml-style imports are used instead of Topoflow-like
 from permamodel.components import perma_base
 

--- a/permamodel/utils/BMI_base.py
+++ b/permamodel/utils/BMI_base.py
@@ -154,7 +154,6 @@ import traceback  # (10/10/10)
 import numpy as np
 
 from .. import data_directory
-
 # import pixels
 from . import outlets  # # (9/19/14)
 from . import rti_files

--- a/permamodel/utils/file_utils.py
+++ b/permamodel/utils/file_utils.py
@@ -24,7 +24,6 @@ SOFTWARE.
 from __future__ import print_function
 
 import glob
-
 ## import os     (for os.remove)
 import os.path
 import time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,9 @@ Repository = "https://github.com/permamodel/permamodel"
 [project.optional-dependencies]
 dev = [
   "black",
+  "flake8",
+  "isort",
+  "nox",
 ]
 build = [
   "build",
@@ -88,3 +91,10 @@ doctest_optionflags = [
   "IGNORE_EXCEPTION_DETAIL",
   "ALLOW_UNICODE"
 ]
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+combine_as_imports = true
+line_length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,14 @@
 [coverage:run]
 relative_files = True
 
+[flake8]
+exclude = docs
+ignore =
+	E203
+	E501
+	W503
+max-line-length = 88
+
 [zest.releaser]
 tag-format = v{version}
 python-file-with-version = permamodel/_version.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,17 @@ relative_files = True
 [flake8]
 ignore =
 	E203
+	E241
+	E262
+	E265
+	E266
+	E402
 	E501
+	E722
+	F401
+	F821
+	F841
+	W291
 	W503
 max-line-length = 88
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,6 @@
 relative_files = True
 
 [flake8]
-exclude = docs
 ignore =
 	E203
 	E501


### PR DESCRIPTION
In this PR, I've updated permamodel to use *nox* for building and testing the project. The available *nox* sessions are:
```
nox --list
Sessions defined in /Users/mpiper/projects/permamodel/noxfile.py:

* test-3.9 -> Run the tests.
* test-3.10 -> Run the tests.
* test-3.11 -> Run the tests.
* format -> Clean lint and assert style.
* build -> Build source and binary distributions.
* release -> Tag, build, and publish a new release to PyPI.
* testpypi -> Upload package to TestPyPI.
* pypi -> Upload package to PyPI.
* clean -> Remove virtual environments, build files, and caches.
* nuke -> Clean and also remove the .nox directory.
```

The Test and Format CI workflows also use these *nox* sessions.