### PR TITLE
Test BMI for FrostNumber and Ku models

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,11 @@ jobs:
         run: |
           nox -s test --python ${{ matrix.python-version }} -- --cov=permamodel --cov-report=xml:./coverage.xml --cov-config=./setup.cfg -vvv
 
+      - name: Test BMI
+        if: ${{ matrix.python-version == '3.9' }}  # stuck at py39 pending pymt update
+        run: |
+          nox -s bmi-test --python ${{ matrix.python-version }}
+
       - name: Coveralls
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
         uses: AndreMiras/coveralls-python-action@v20201129

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           nox -s test --python ${{ matrix.python-version }} -- --cov=permamodel --cov-report=xml:./coverage.xml --cov-config=./setup.cfg -vvv
 
       - name: Test BMI
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'  # stuck at py39 pending pymt update
+        if: matrix.python-version == '3.9'  # stuck at py39 pending pymt update
         run: |
           nox -s test-bmi --python ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           nox -s test --python ${{ matrix.python-version }} -- --cov=permamodel --cov-report=xml:./coverage.xml --cov-config=./setup.cfg -vvv
 
       - name: Test BMI
-        if: ${{ matrix.python-version == '3.9' }}  # stuck at py39 pending pymt update
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'  # stuck at py39 pending pymt update
         run: |
           nox -s test-bmi --python ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Test BMI
         if: ${{ matrix.python-version == '3.9' }}  # stuck at py39 pending pymt update
         run: |
-          nox -s bmi-test --python ${{ matrix.python-version }}
+          nox -s test-bmi --python ${{ matrix.python-version }}
 
       - name: Coveralls
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           nox -s test --python ${{ matrix.python-version }} -- --cov=permamodel --cov-report=xml:./coverage.xml --cov-config=./setup.cfg -vvv
 
       - name: Test BMI
-        if: matrix.python-version == '3.9'  # stuck at py39 pending pymt update
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'  # stuck at py39 pending pymt update
         run: |
           nox -s test-bmi --python ${{ matrix.python-version }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.nox/
 .coverage
 .coverage.*
 .cache

--- a/.gitignore
+++ b/.gitignore
@@ -80,5 +80,3 @@ target/
 
 
 frostnumber_output.dat
-
-permamodel/components/bmi_frost_number.py

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,13 +27,13 @@ def test_bmi(session: nox.Session) -> None:
     session.install(".")
     tmpdir = session.create_tmp()
     session.run(
-	    "bmi-test",
+        "bmi-test",
         "permamodel.components.bmi_frost_number:BmiFrostnumberMethod",
         "--config-file",
         "./permamodel/examples/Frostnumber_example_singlesite_singleyear.cfg",
-	    "--root-dir",
-	    tmpdir,
-	    "-vvv",
+        "--root-dir",
+        tmpdir,
+        "-vvv",
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,6 +20,23 @@ def test(session: nox.Session) -> None:
     session.run("pytest", *args)
 
 
+@nox.session(name="test-bmi", python=PYTHON_VERSIONS, venv_backend="conda")
+def test_bmi(session: nox.Session) -> None:
+    """Test the Basic Model Interface."""
+    session.conda_install("bmi-tester", "pymt>=1.3")
+    session.install(".")
+    tmpdir = session.create_tmp()
+    session.run(
+	    "bmi-test",
+        "permamodel.components.bmi_frost_number:BmiFrostnumberMethod",
+        "--config-file",
+        "./permamodel/examples/Frostnumber_example_singlesite_singleyear.cfg",
+	    "--root-dir",
+	    tmpdir,
+	    "-vvv",
+    )
+
+
 @nox.session
 def format(session: nox.Session) -> None:
     """Clean lint and assert style."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -25,24 +25,24 @@ def test_bmi(session: nox.Session) -> None:
     """Test the Basic Model Interface."""
     session.conda_install("bmi-tester", "pymt>=1.3")
     session.install(".")
-    fn_tmpdir = session.create_tmp()
+    os.mkdir("fn")
     session.run(
         "bmi-test",
         "permamodel.components.bmi_frost_number:BmiFrostnumberMethod",
         "--config-file",
         "./permamodel/examples/Frostnumber_example_singlesite_singleyear.cfg",
         "--root-dir",
-        fn_tmpdir,
+        "fn",
         "-vvv",
     )
-    ku_tmpdir = session.create_tmp()
+    os.mkdir("ku")
     session.run(
         "bmi-test",
         "permamodel.components.bmi_Ku_component:BmiKuMethod",
         "--config-file",
         "./permamodel/examples/Ku_method.cfg",
         "--root-dir",
-        ku_tmpdir,
+        "ku",
         "-vvv",
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -38,7 +38,7 @@ def test_bmi(session: nox.Session) -> None:
     ku_tmpdir = session.create_tmp()
     session.run(
         "bmi-test",
-        "permamodel.components.bmi_ku_component:BmiKuMethod",
+        "permamodel.components.bmi_Ku_component:BmiKuMethod",
         "--config-file",
         "./permamodel/examples/Ku_method.cfg",
         "--root-dir",

--- a/noxfile.py
+++ b/noxfile.py
@@ -25,14 +25,23 @@ def test_bmi(session: nox.Session) -> None:
     """Test the Basic Model Interface."""
     session.conda_install("bmi-tester", "pymt>=1.3")
     session.install(".")
-    tmpdir = session.create_tmp()
+    fn_tmpdir = session.create_tmp()
     session.run(
         "bmi-test",
         "permamodel.components.bmi_frost_number:BmiFrostnumberMethod",
         "--config-file",
         "./permamodel/examples/Frostnumber_example_singlesite_singleyear.cfg",
         "--root-dir",
-        tmpdir,
+        fn_tmpdir,
+        "-vvv",
+    ku_tmpdir = session.create_tmp()
+    session.run(
+        "bmi-test",
+        "permamodel.components.bmi_ku_component:BmiKuMethod",
+        "--config-file",
+        "./permamodel/examples/Ku_method.cfg",
+        "--root-dir",
+        ku_tmpdir,
         "-vvv",
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,6 +34,7 @@ def test_bmi(session: nox.Session) -> None:
         "--root-dir",
         fn_tmpdir,
         "-vvv",
+    )
     ku_tmpdir = session.create_tmp()
     session.run(
         "bmi-test",

--- a/permamodel/components/bmi_frost_number.py
+++ b/permamodel/components/bmi_frost_number.py
@@ -30,9 +30,10 @@ from permamodel.components import frost_number, perma_base
 
 
 class BmiFrostnumberMethod(perma_base.PermafrostComponent):
-    """ Implement BMI interface to the Nelson-Outcalt Frost number code """
+    """Implement BMI interface to the Nelson-Outcalt Frost number code"""
+
     def __init__(self):
-        """ This overwrites __init__() method of PermafrostComponent """
+        """This overwrites __init__() method of PermafrostComponent"""
         self._name = "Permamodel Frostnumber Component"
         self._model = None
         self.model = None
@@ -42,48 +43,50 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
         self._grid_type = {}
 
         self._att_map = {
-            'model_name': 'PermaModel_frostnumber_method',
-            'version':            '0.1',
-            'author_name':        'J. Scott Stewart and Elchin Jafarov',
-            'grid_type':          'none',
-            'time_step_type':     'fixed',
-            'step_method':        'explicit',
-            #-------------------------------------------------------------
-            'comp_name':          'frostnumber',
-            'model_family':       'PermaModel',
-            'cfg_extension':      '_frostnumber_model.cfg',
-            'cmt_var_prefix':     '/input/',
-            'gui_yaml_file':      '/input/frostnumber_model.yaml',
-            'time_units':         'years'}
+            "model_name": "PermaModel_frostnumber_method",
+            "version": "0.1",
+            "author_name": "J. Scott Stewart and Elchin Jafarov",
+            "grid_type": "none",
+            "time_step_type": "fixed",
+            "step_method": "explicit",
+            # -------------------------------------------------------------
+            "comp_name": "frostnumber",
+            "model_family": "PermaModel",
+            "cfg_extension": "_frostnumber_model.cfg",
+            "cmt_var_prefix": "/input/",
+            "gui_yaml_file": "/input/frostnumber_model.yaml",
+            "time_units": "years",
+        }
 
         self._input_var_names = (
-            'atmosphere_bottom_air__time_min_of_temperature',
-            'atmosphere_bottom_air__time_max_of_temperature',
+            "atmosphere_bottom_air__time_min_of_temperature",
+            "atmosphere_bottom_air__time_max_of_temperature",
         )
 
         self._output_var_names = (
-            'frostnumber__air',            # Air Frost number
-            'frostnumber__surface',        # Surface Frost number
-            'frostnumber__stefan')        # Stefan Frost number
+            "frostnumber__air",  # Air Frost number
+            "frostnumber__surface",  # Surface Frost number
+            "frostnumber__stefan",
+        )  # Stefan Frost number
 
         self._var_name_map = {
-            'atmosphere_bottom_air__time_min_of_temperature': 'T_air_min',
-            'atmosphere_bottom_air__time_max_of_temperature': 'T_air_max',
-            'frostnumber__air': 'air_frost_number',
-            'frostnumber__surface': 'surface_frost_number',
-            'frostnumber__stefan': 'stefan_frost_number',
+            "atmosphere_bottom_air__time_min_of_temperature": "T_air_min",
+            "atmosphere_bottom_air__time_max_of_temperature": "T_air_max",
+            "frostnumber__air": "air_frost_number",
+            "frostnumber__surface": "surface_frost_number",
+            "frostnumber__stefan": "stefan_frost_number",
         }
 
         self._var_units_map = {
-            'atmosphere_bottom_air__time_min_of_temperature': 'deg_C',
-            'atmosphere_bottom_air__time_max_of_temperature': 'deg_C',
-            'frostnumber__air': '1',
-            'frostnumber__surface': '1',
-            'frostnumber__stefan': '1',
+            "atmosphere_bottom_air__time_min_of_temperature": "deg_C",
+            "atmosphere_bottom_air__time_max_of_temperature": "deg_C",
+            "frostnumber__air": "1",
+            "frostnumber__surface": "1",
+            "frostnumber__stefan": "1",
         }
 
     def initialize(self, cfg_file=None):
-        """ this overwrites initialize() in PermafrostComponent """
+        """this overwrites initialize() in PermafrostComponent"""
         self._model = frost_number.FrostnumberMethod()
         # This allows testing to not use protected access to _model
         self.model = self._model
@@ -105,11 +108,11 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
         gridnumber = 0
         for varname in self._input_var_names:
             self._grids[gridnumber] = varname
-            self._grid_type[gridnumber] = 'scalar'
+            self._grid_type[gridnumber] = "scalar"
             gridnumber += 1
         for varname in self._output_var_names:
             self._grids[gridnumber] = varname
-            self._grid_type[gridnumber] = 'scalar'
+            self._grid_type[gridnumber] = "scalar"
             gridnumber += 1
 
         # Set the internal (frost number) variables that correspond
@@ -118,11 +121,11 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
         self._values = {
             # These are the links to the model's variables and
             # should be consistent with _var_name_map
-            'atmosphere_bottom_air__time_min_of_temperature': self._model.T_air_min,
-            'atmosphere_bottom_air__time_max_of_temperature': self._model.T_air_max,
-            'frostnumber__air':         self._model.air_frost_number,
-            'frostnumber__surface':     self._model.surface_frost_number,
-            'frostnumber__stefan':      self._model.stefan_frost_number,
+            "atmosphere_bottom_air__time_min_of_temperature": self._model.T_air_min,
+            "atmosphere_bottom_air__time_max_of_temperature": self._model.T_air_max,
+            "frostnumber__air": self._model.air_frost_number,
+            "frostnumber__surface": self._model.surface_frost_number,
+            "frostnumber__stefan": self._model.stefan_frost_number,
         }
 
     def get_attribute(self, att_name):
@@ -132,18 +135,16 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
             raise KeyError("No attribute %s" % str(att_name))
 
     def get_input_var_names(self):
-        #--------------------------------------------------------
+        # --------------------------------------------------------
         # Note: These are currently variables needed from other
         #       components vs. those read from files or GUI.
-        #--------------------------------------------------------
+        # --------------------------------------------------------
         return self._input_var_names
 
     def get_output_var_names(self):
-
         return self._output_var_names
 
     def get_var_name(self, long_var_name):
-
         return self._var_name_map[long_var_name]
 
     def get_var_units(self, long_var_name):
@@ -153,26 +154,26 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
         return "node"
 
     def update(self):
-        """ This overwrites update() in Permafrost component
-            and has different number of arguments """
+        """This overwrites update() in Permafrost component
+        and has different number of arguments"""
         # Calculate the new frost number values
         self._model.update()
-        self._values['frostnumber__air'] = self._model.air_frost_number
+        self._values["frostnumber__air"] = self._model.air_frost_number
 
     def update_frac(self, time_fraction):
-        """ This is for BMI compliance """
+        """This is for BMI compliance"""
         # Only increment the time by a partial time step
         # Currently, only non-fractions are allowed, but this could be
         #  0, 1, 2, ...
         self._model.update(frac=time_fraction)
-        self._values['frostnumber__air'] = self._model.air_frost_number
+        self._values["frostnumber__air"] = self._model.air_frost_number
 
     def get_year_from_timestep(self, this_timestep):
-        """ given the timestep, return the year """
+        """given the timestep, return the year"""
         return int(self.get_time_step() * this_timestep + self._model.start_year)
 
     def update_until(self, stop_time):
-        """ BMI-required, run until a specified time """
+        """BMI-required, run until a specified time"""
         stop_year = self.get_year_from_timestep(stop_time)
 
         # Ensure that stop_year is at least the current year
@@ -199,28 +200,28 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
                 year = self._model.year
 
     def finalize(self):
-        """ BMI-required, wrap up all things including writing output """
+        """BMI-required, wrap up all things including writing output"""
         # Write output last output
         self._model.write_output_to_file()
 
     def get_start_time(self):
-        """ BMI-required although all WMT models start at time=0 """
+        """BMI-required although all WMT models start at time=0"""
         return 0.0
 
     def get_current_time(self):
-        """ Number of timesteps (years) since start of model run """
+        """Number of timesteps (years) since start of model run"""
         return float(self._model.year - self._model.start_year)
 
     def get_end_time(self):
-        """ Number of timestesp (years) so that last year is included """
+        """Number of timestesp (years) so that last year is included"""
         return float(self._model.end_year - self._model.start_year)
 
     def get_grid_type(self, grid_number):
-        """ BMI: inquire about the type of this grid """
+        """BMI: inquire about the type of this grid"""
         return self._grid_type[grid_number]
 
     def get_time_step(self):
-        """ BMI: return the time step value (years) """
+        """BMI: return the time step value (years)"""
         return float(self._model.dt)
 
     def get_value_ref(self, var_name):
@@ -239,7 +240,7 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
         return self._values[var_name]
 
     def set_value(self, var_name, new_var_values):
-        """ BMI: allow external set-access to model variable """
+        """BMI: allow external set-access to model variable"""
         array = getattr(self._model, self._var_name_map[var_name])
         if len(array) == 1:
             array[0] = new_var_values
@@ -250,19 +251,19 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
         # self._values[var_name] = new_var_values
 
     def set_value_at_indices(self, var_name, new_var_values, indices):
-        """ BMI: allow external set-access to model array variable """
+        """BMI: allow external set-access to model array variable"""
         self.get_value_ref(var_name).flat[indices] = new_var_values
 
     def get_var_itemsize(self, var_name):
-        """ BMI: determine how many bytes a variable uses """
+        """BMI: determine how many bytes a variable uses"""
         return np.asarray(self.get_value_ref(var_name)).flatten()[0].nbytes
 
     def get_value_at_indices(self, var_name, indices):
-        """ BMI: allow external get-access to model array variable """
+        """BMI: allow external get-access to model array variable"""
         return self.get_value_ref(var_name).take(indices)
 
     def get_var_nbytes(self, var_name):
-        """ BMI: number of bytes of a variable """
+        """BMI: number of bytes of a variable"""
         return np.asarray(self.get_value_ref(var_name)).nbytes
 
     def get_value(self, var_name, out=None):
@@ -279,14 +280,14 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
             Copy of values.
         """
         # Original version: from bmi_heat.py
-        #return self.get_value_ref(var_name).copy()
+        # return self.get_value_ref(var_name).copy()
 
         # Version to convert to numpy array for bmi-tester compliance
         # Note: converting to np arrays on the fly here
         # Note: float values don't have a copy() function
-        #try:
+        # try:
         #    return np.array(self.get_value_ref(var_name).copy())
-        #except AttributeError:
+        # except AttributeError:
         #    return np.array(self.get_value_ref(var_name))
         if out is None:
             out = self.get_value_ref(var_name).copy()
@@ -310,7 +311,7 @@ class BmiFrostnumberMethod(perma_base.PermafrostComponent):
         return str(self.get_value_ref(var_name).dtype)
 
     def get_component_name(self):
-        """ BMI: provide this component's name """
+        """BMI: provide this component's name"""
         return self._name
 
     # Copied from bmi_heat.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,9 +70,15 @@ testing = [
 readme = {file = ["README.md", "LICENSE"], content-type = "text/markdown"}
 version = {attr = "permamodel._version.__version__"}
 
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.package-data]
+permamodel = ["data/*"]
+
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["permamodel*", "permamodel/data"]
+include = ["permamodel*"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ version = {attr = "permamodel._version.__version__"}
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["permamodel*"]
+include = ["permamodel*", "permamodel/data"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"


### PR DESCRIPTION
This PR adds a *nox* session that runs *bmi-tester* on the FrontNumber and Ku models. The *nox* session is also called in the *Test* CI workflow.

Two notes:
* The Ku model needs the `permamodel/data` directory to be included as package data.
* The file `permamodel/components/bmi_frost_number.py` was (accidentally?) ignored, but no longer.