### PR TITLE
Fix coverage reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Test
         run: |
-          nox -s test --python ${{ matrix.python-version }} -- --cov=permamodel --cov-report=xml:./coverage.xml --cov-config=./setup.cfg -vvv
+          nox -s test --python ${{ matrix.python-version }}
 
       - name: Test BMI
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'  # stuck at py39 pending pymt update
@@ -47,4 +47,4 @@ jobs:
 
       - name: Coveralls
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
-        uses: AndreMiras/coveralls-python-action@v20201129
+        uses: AndreMiras/coveralls-python-action@develop

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Test](https://github.com/permamodel/permamodel/actions/workflows/test.yml/badge.svg)](https://github.com/permamodel/permamodel/actions/workflows/test.yml)
-[![Coverage Status](https://coveralls.io/repos/permamodel/permamodel/badge.svg?branch=master)](https://coveralls.io/r/permamodel/permamodel?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/permamodel/permamodel/badge.svg?branch=main)](https://coveralls.io/github/permamodel/permamodel?branch=main)
 
 # permamodel
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,8 +20,6 @@ def test(session: nox.Session) -> None:
     session.install(".[testing]")
 
     args = [
-        "-n",
-        "auto",
         "--cov",
         PROJECT,
         "-vvv",

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,8 +18,21 @@ BUILD_DIR = ROOT / "build"
 def test(session: nox.Session) -> None:
     """Run the tests."""
     session.install(".[testing]")
-    args = session.posargs or ["--cov", "--cov-report=term", "-vvv"]
+
+    args = [
+        "-n",
+        "auto",
+        "--cov",
+        PROJECT,
+        "-vvv",
+    ] + session.posargs
+
+    if "CI" in os.environ:
+        args.append(f"--cov-report=xml:{ROOT.absolute()!s}/coverage.xml")
     session.run("pytest", *args)
+
+    if "CI" not in os.environ:
+        session.run("coverage", "report", "--ignore-errors", "--show-missing")
 
 
 @nox.session(name="test-bmi", python=PYTHON_VERSIONS, venv_backend="conda")


### PR DESCRIPTION
This PR fixes a problem in reporting coverage scores to Coveralls. The error message in the GitHub Actions logs wasn't very helpful, but I noticed that this action is working correctly in the Landlab CI testing, so I adopted code @mcflugen wrote for its nox testing session. This fixed the problem. I think the key was providing a correct path to the coverage output file.

I also updated the URL in the Coveralls badge in the README.