### PR TITLE
Update Ku BMI for pymt

### DIFF
--- a/permamodel/components/bmi_Ku.py
+++ b/permamodel/components/bmi_Ku.py
@@ -97,7 +97,6 @@ class BmiKuModel:
         for var in self._output_var_names:
             self._values[var] = np.empty(
                 (
-                    self._model.number_of_years,
                     self._model.grid_shape[0],
                     self._model.grid_shape[1],
                 )
@@ -121,7 +120,6 @@ class BmiKuModel:
         self._start_time = 0.0
         self._end_time = self._model.number_of_years
         self._grid_shape = (
-            self._model.number_of_years,
             self._model.grid_shape[0],
             self._model.grid_shape[1],
         )

--- a/permamodel/components/bmi_Ku.py
+++ b/permamodel/components/bmi_Ku.py
@@ -126,7 +126,7 @@ class BmiKuModel:
 
     def update(self):
         """Run the model for the current time step."""
-        self._model.run_one_step(self._current_time)
+        self._model.run_one_step(int(self._current_time))
         self._current_time += 1.0
 
     def update_until(self, end_time: int):

--- a/permamodel/components/bmi_Ku.py
+++ b/permamodel/components/bmi_Ku.py
@@ -265,7 +265,7 @@ class BmiKuModel:
         coords = [getattr(self._model, var)[dim] for dim in dims]
         diffs = [np.diff(array)[0] for array in coords]
 
-        spacing[:] = diffs
+        spacing[:] = diffs[-2:]
         return spacing
 
     def get_grid_origin(self, grid: int, origin: np.ndarray) -> np.ndarray:

--- a/permamodel/components/bmi_Ku.py
+++ b/permamodel/components/bmi_Ku.py
@@ -275,8 +275,8 @@ class BmiKuModel:
         ydim = getattr(self._model, var).dims[1]
         xdim = getattr(self._model, var).dims[2]
 
-        y0 = getattr(self._model, var)[ydim][0, 0]
-        x0 = getattr(self._model, var)[xdim][0, 0]
+        y0 = getattr(self._model, var)[ydim][0]
+        x0 = getattr(self._model, var)[xdim][0]
 
         origin[:] = [y0, x0]
         return origin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "Intended Audience :: Education",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
   "affine",
   "netCDF4",


### PR DESCRIPTION
This PR includes some minor modifications to the (new) Ku model BMI so that it works with *pymt*.

1. The new Ku model uses an internal shape of *(time, x, y)*. The BMI only cares about the spatial dimensions (time is handled separately), so I removed the time dimension in the BMI.
2. BMI requires time to be a float, while Ku requires it to be an int. I downcast the time from float to int when calling the BMI `update` method. 
3. When calculating grid spacing, only use spatial dimensions from Ku model, not the time dimension.

I also fixed a minor indexing issue that previously escaped notice.