### PR TITLE
Update Ku to allow scalar inputs

### DIFF
--- a/permamodel/components/Ku.py
+++ b/permamodel/components/Ku.py
@@ -181,6 +181,12 @@ class Ku_model:
         """Read input data files and store fields as instance variables."""
 
         # Raise an error if there is no information about variables.
+        if not hasattr(self, info):
+            raise ValueError(
+                "Did not find information about input variables: did you call read_config() first?"
+            )
+
+
         if len(self.info) == 0:
             raise ValueError(
                 "No input variables found: did you call read_config() first?"

--- a/permamodel/components/Ku.py
+++ b/permamodel/components/Ku.py
@@ -181,11 +181,10 @@ class Ku_model:
         """Read input data files and store fields as instance variables."""
 
         # Raise an error if there is no information about variables.
-        if not hasattr(self, info):
+        if not hasattr(self, 'info'):
             raise ValueError(
                 "Did not find information about input variables: did you call read_config() first?"
             )
-
 
         if len(self.info) == 0:
             raise ValueError(

--- a/permamodel/components/Ku.py
+++ b/permamodel/components/Ku.py
@@ -181,7 +181,7 @@ class Ku_model:
         """Read input data files and store fields as instance variables."""
 
         # Raise an error if there is no information about variables.
-        if not hasattr(self, 'info'):
+        if not hasattr(self, "info"):
             raise ValueError(
                 "Did not find information about input variables: did you call read_config() first?"
             )

--- a/permamodel/examples/Ku_bmi_example_config.toml
+++ b/permamodel/examples/Ku_bmi_example_config.toml
@@ -8,16 +8,41 @@ outputs_dir = "permamodel/data/test_directory/outputs/"
 number_of_years = 100 # time
 grid_shape = [100, 100] # [y, x]
 
-[files]
-air_temperature_file = "air_temperature.nc"
-temperature_amplitude_file = "temperature_amplitude.nc"
-snow_thickness_file = "snow_thickness.nc"
-snow_density_file = "snow_density.nc"
-soil_water_content_file = "soil_water_content.nc"
-frozen_vegetation_height_file = "frozen_vegetation_height.nc"
-thawed_vegetation_height_file = "thawed_vegetation_height.nc"
-frozen_vegetation_diffusivity_file = "frozen_vegetation_diffusivity.nc"
-thawed_vegetation_diffusivity_file = "thawed_vegetation_diffusivity.nc"
+[variables.air_temperature]
+nc_file = 'air_temperature.nc'
+scalar = -999
+
+[variables.temperature_amplitude]
+nc_file = 'temperature_amplitude.nc'
+scalar = -999
+
+[variables.snow_thickness]
+nc_file = 'snow_thickness.nc'
+scalar = -999
+
+[variables.snow_density]
+nc_file = 'snow_density.nc'
+scalar = 240.0
+
+[variables.soil_water_content]
+nc_file = 'soil_water_content.nc'
+scalar = -999
+
+[variables.frozen_vegetation_height]
+nc_file = ''
+scalar = 0.1
+
+[variables.thawed_vegetation_height]
+nc_file = ''
+scalar = 0.1
+
+[variables.frozen_vegetation_diffusivity]
+nc_file = ''
+scalar = 2.39e-6
+
+[variables.thawed_vegetation_diffusivity]
+nc_file = ''
+scalar = 1.0556e-6
 
 [soils.sand]
 scalar_fraction = 0.25

--- a/permamodel/examples/Ku_example_config.toml
+++ b/permamodel/examples/Ku_example_config.toml
@@ -8,16 +8,41 @@ outputs_dir = "permamodel/data/test_directory/outputs/"
 number_of_years = 100 # time
 grid_shape = [100, 100] # [y, x]
 
-[files]
-air_temperature_file = "air_temperature.nc"
-temperature_amplitude_file = "temperature_amplitude.nc"
-snow_thickness_file = "snow_thickness.nc"
-snow_density_file = "snow_density.nc"
-soil_water_content_file = "soil_water_content.nc"
-frozen_vegetation_height_file = "frozen_vegetation_height.nc"
-thawed_vegetation_height_file = "thawed_vegetation_height.nc"
-frozen_vegetation_diffusivity_file = "frozen_vegetation_diffusivity.nc"
-thawed_vegetation_diffusivity_file = "thawed_vegetation_diffusivity.nc"
+[variables.air_temperature]
+nc_file = 'air_temperature.nc'
+scalar = -999
+
+[variables.temperature_amplitude]
+nc_file = 'temperature_amplitude.nc'
+scalar = -999
+
+[variables.snow_thickness]
+nc_file = 'snow_thickness.nc'
+scalar = -999
+
+[variables.snow_density]
+nc_file = 'snow_density.nc'
+scalar = 240.0
+
+[variables.soil_water_content]
+nc_file = 'soil_water_content.nc'
+scalar = -999
+
+[variables.frozen_vegetation_height]
+nc_file = ''
+scalar = 0.1
+
+[variables.thawed_vegetation_height]
+nc_file = ''
+scalar = 0.1
+
+[variables.frozen_vegetation_diffusivity]
+nc_file = ''
+scalar = 2.39e-6
+
+[variables.thawed_vegetation_diffusivity]
+nc_file = ''
+scalar = 1.0556e-6
 
 [soils.sand]
 scalar_fraction = 0.25

--- a/permamodel/tests/test_Ku.py
+++ b/permamodel/tests/test_Ku.py
@@ -27,7 +27,7 @@ def test_read_config(Ku):
     assert Ku.outputs_dir == "permamodel/data/test_directory/outputs/"
     assert Ku.number_of_years == 100
     assert Ku.grid_shape == [100, 100]
-    assert len(Ku.input_files) > 0
+    assert len(Ku.info) > 0
     assert Ku.soils["sand"]["heat_capacity"] == 1500
     assert len(Ku.constants) > 0
 


### PR DESCRIPTION
Typically, users specify values of input fields to the Ku model using netCDF files. While it's always possible to overwrite Ku's variable fields directly, this update also allows users to specify scalar inputs in the configuration file, or even to initialize the model without any input data (if, e.g., coupling to climate reanalysis data at each update step). 